### PR TITLE
refactor: use `c` instead of destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Cli.create('greet', {
   args: z.object({
     name: z.string().describe('Name to greet'),
   }),
-  run({ args }) {
-    return { message: `hello ${args.name}` }
+  run(c) {
+    return { message: `hello ${c.args.name}` }
   },
 }).serve()
 ```
@@ -124,7 +124,7 @@ Cli.create('my-cli', {
       saveDev: z.boolean().optional().describe('Save as dev dependency'),
     }),
     alias: { saveDev: 'D' },
-    run({ args }) {
+    run(c) {
       return { added: 1, packages: 451 }
     },
   })
@@ -176,8 +176,8 @@ const pr = Cli.create('pr', { description: 'Pull request commands' }).command('l
   options: z.object({
     state: z.enum(['open', 'closed', 'all']).default('open'),
   }),
-  run({ options }) {
-    return { prs: [], state: options.state }
+  run(c) {
+    return { prs: [], state: c.options.state }
   },
 })
 
@@ -264,9 +264,9 @@ Return CTAs from `ok()` or `error()` to suggest next steps. `cta` parameters are
 ```ts
 cli.command('list', {
   args: z.object({ state: z.enum(['open', 'closed']).default('open') }),
-  run({ args, ok }) {
+  run(c) {
     const items = [{ id: 1, title: 'Fix bug' }]
-    return ok({ items }, {
+    return c.ok({ items }, {
       cta: {
         commands: [
           { command: 'get 1', description: 'View item' },
@@ -364,8 +364,8 @@ cli.command('deploy', {
   options: z.object({ force: z.boolean().optional() }),
   env: z.object({ DEPLOY_TOKEN: z.string() }),
   output: z.object({ url: z.string(), duration: z.number() }),
-  run({ args, options, env }) {
-    return { url: `https://${args.env}.example.com`, duration: 3.2 }
+  run(c) {
+    return { url: `https://${c.args.env}.example.com`, duration: 3.2 }
   },
 })
 ```
@@ -404,10 +404,10 @@ async *run() {
 Use `ok()` or `error()` as the return value to attach CTAs or signal failure:
 
 ```ts
-async *run({ ok }) {
+async *run(c) {
   yield { step: 1 }
   yield { step: 2 }
-  return ok(undefined, { cta: { commands: ['status'] } })
+  return c.ok(undefined, { cta: { commands: ['status'] } })
 }
 ```
 
@@ -420,13 +420,13 @@ cli.command('greet', {
   args: z.object({ name: z.string() }),
   options: z.object({ loud: z.boolean().default(false) }),
   output: z.object({ message: z.string() }),
-  run({ args, options, ok }) {
-    args.name
-    //   ^? (property) name: string
-    options.loud
-    //      ^? (property) loud: boolean
-    return ok({ message: `hello ${args.name}` }, {  
-    //          ^? (property) message: string
+  run(c) {
+    c.args.name
+    //     ^? (property) name: string
+    c.options.loud
+    //        ^? (property) loud: boolean
+    return c.ok({ message: `hello ${c.args.name}` }, {  
+    //            ^? (property) message: string
       cta: { commands: ['greet world'] },
     //                   ^? 'greet' | 'other-cmd'
     })

--- a/examples/npm/cli.ts
+++ b/examples/npm/cli.ts
@@ -34,8 +34,8 @@ cli.command('install', {
     },
     { options: { global: true }, args: { package: 'tsx' }, description: 'Install globally' },
   ],
-  run({ args }) {
-    if (!args.package) return { added: 120, removed: 0, changed: 0, packages: 450 }
+  run(c) {
+    if (!c.args.package) return { added: 120, removed: 0, changed: 0, packages: 450 }
     return { added: 1, removed: 0, changed: 0, packages: 451 }
   },
 })
@@ -53,9 +53,9 @@ cli.command('info', {
     homepage: z.string(),
   }),
   examples: [{ args: { package: 'express' }, description: 'View info for express' }],
-  run({ args }) {
+  run(c) {
     return {
-      name: args.package,
+      name: c.args.package,
       version: '4.21.2',
       description: 'Fast, unopinionated, minimalist web framework',
       license: 'MIT',
@@ -102,8 +102,8 @@ cli.command('publish', {
     { options: { tag: 'beta' }, description: 'Publish as beta' },
     { options: { dryRun: true }, description: 'Dry run' },
   ],
-  run({ options }) {
-    return { name: 'my-package', version: '1.0.0', tag: options.tag }
+  run(c) {
+    return { name: 'my-package', version: '1.0.0', tag: c.options.tag }
   },
 })
 
@@ -120,8 +120,8 @@ cli.command('run', {
     { args: { script: 'test' }, description: 'Run tests' },
     { args: { script: 'build' }, description: 'Run build' },
   ],
-  run({ args }) {
-    return { script: args.script, exitCode: 0 }
+  run(c) {
+    return { script: c.args.script, exitCode: 0 }
   },
 })
 

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -5,8 +5,8 @@ test('args in run() infers from args schema', () => {
   const cli = Cli.create('test')
   cli.command('greet', {
     args: z.object({ name: z.string() }),
-    run({ args }) {
-      expectTypeOf(args).toEqualTypeOf<{ name: string }>()
+    run(c) {
+      expectTypeOf(c.args).toEqualTypeOf<{ name: string }>()
       return {}
     },
   })
@@ -19,8 +19,8 @@ test('options in run() infers from options schema', () => {
       state: z.enum(['open', 'closed']).default('open'),
       limit: z.number().default(30),
     }),
-    run({ options }) {
-      expectTypeOf(options).toEqualTypeOf<{ state: 'open' | 'closed'; limit: number }>()
+    run(c) {
+      expectTypeOf(c.options).toEqualTypeOf<{ state: 'open' | 'closed'; limit: number }>()
       return {}
     },
   })
@@ -29,9 +29,9 @@ test('options in run() infers from options schema', () => {
 test('without schemas, run receives empty objects', () => {
   const cli = Cli.create('test')
   cli.command('ping', {
-    run({ args, options }) {
-      expectTypeOf(args).toEqualTypeOf<{}>()
-      expectTypeOf(options).toEqualTypeOf<{}>()
+    run(c) {
+      expectTypeOf(c.args).toEqualTypeOf<{}>()
+      expectTypeOf(c.options).toEqualTypeOf<{}>()
       return { pong: true }
     },
   })
@@ -75,16 +75,16 @@ test('ok() data param is typed from output schema', () => {
   const cli = Cli.create('test')
   cli.command('list', {
     output: z.object({ items: z.array(z.string()) }),
-    run({ ok }) {
-      return ok({ items: ['a', 'b'] })
+    run(c) {
+      return c.ok({ items: ['a', 'b'] })
     },
   })
 
   cli.command('list2', {
     output: z.object({ items: z.array(z.string()) }),
-    run({ ok }) {
+    run(c) {
       // @ts-expect-error — data doesn't match output schema
-      return ok({ wrong: 123 })
+      return c.ok({ wrong: 123 })
     },
   })
 })
@@ -119,7 +119,7 @@ test('command() accumulates command types through chaining', () => {
     .command('get', {
       args: z.object({ id: z.number() }),
       options: z.object({ verbose: z.boolean().default(false) }),
-      run: ({ args }) => ({ id: args.id }),
+      run: (c) => ({ id: c.args.id }),
     })
     .command('list', {
       options: z.object({ limit: z.number().default(30) }),

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -46,8 +46,8 @@ describe('command', () => {
     const cli = Cli.create('test')
     const result = cli.command('greet', {
       args: z.object({ name: z.string() }),
-      run({ args }) {
-        return { message: `hello ${args.name}` }
+      run(c) {
+        return { message: `hello ${c.args.name}` }
       },
     })
     expect(result).toBe(cli)
@@ -59,8 +59,8 @@ describe('serve', () => {
     const cli = Cli.create('test')
     cli.command('greet', {
       args: z.object({ name: z.string() }),
-      run({ args }) {
-        return { message: `hello ${args.name}` }
+      run(c) {
+        return { message: `hello ${c.args.name}` }
       },
     })
 
@@ -75,8 +75,8 @@ describe('serve', () => {
     const cli = Cli.create('test')
     cli.command('greet', {
       args: z.object({ name: z.string() }),
-      run({ args }) {
-        return { message: `hello ${args.name}` }
+      run(c) {
+        return { message: `hello ${c.args.name}` }
       },
     })
 
@@ -97,8 +97,8 @@ describe('serve', () => {
     let receivedArgs: any
     cli.command('add', {
       args: z.object({ a: z.string(), b: z.string() }),
-      run({ args }) {
-        receivedArgs = args
+      run(c) {
+        receivedArgs = c.args
         return {}
       },
     })
@@ -191,8 +191,8 @@ describe('serve', () => {
     const cli = Cli.create('test')
     cli.command('greet', {
       args: z.object({ name: z.string() }),
-      run({ args }) {
-        return { message: `hello ${args.name}` }
+      run(c) {
+        return { message: `hello ${c.args.name}` }
       },
     })
 
@@ -653,8 +653,8 @@ describe('cta', () => {
   test('string shorthand for cta commands', async () => {
     const cli = Cli.create('test')
     cli.command('list', {
-      run({ ok }) {
-        return ok({ items: [] }, { cta: { commands: ['get 1', 'get 2'] } })
+      run(c) {
+        return c.ok({ items: [] }, { cta: { commands: ['get 1', 'get 2'] } })
       },
     })
 
@@ -669,8 +669,8 @@ describe('cta', () => {
   test('tuple shorthand with description', async () => {
     const cli = Cli.create('test')
     cli.command('list', {
-      run({ ok }) {
-        return ok(
+      run(c) {
+        return c.ok(
           { items: [] },
           {
             cta: { commands: [{ command: 'get 1', description: 'View item 1' }] },
@@ -689,8 +689,8 @@ describe('cta', () => {
   test('tuple form with args/options', async () => {
     const cli = Cli.create('test')
     cli.command('create', {
-      run({ ok }) {
-        return ok(
+      run(c) {
+        return c.ok(
           { id: 1 },
           {
             cta: {
@@ -718,8 +718,8 @@ describe('cta', () => {
   test('tuple form boolean args format as placeholders', async () => {
     const cli = Cli.create('test')
     cli.command('list', {
-      run({ ok }) {
-        return ok(
+      run(c) {
+        return c.ok(
           { items: [] },
           {
             cta: { commands: [{ command: 'get', args: { id: true }, options: { format: true } }] },
@@ -736,8 +736,8 @@ describe('cta', () => {
   test('custom cta description', async () => {
     const cli = Cli.create('test')
     cli.command('create', {
-      run({ ok }) {
-        return ok(
+      run(c) {
+        return c.ok(
           { id: 1 },
           {
             cta: { description: 'View the created item:', commands: ['get 1'] },
@@ -1172,8 +1172,8 @@ describe('env', () => {
       env: z.object({
         API_TOKEN: z.string().describe('Auth token'),
       }),
-      run({ env }) {
-        receivedEnv = env
+      run(c) {
+        receivedEnv = c.env
         return { ok: true }
       },
     })
@@ -1205,8 +1205,8 @@ describe('env', () => {
       env: z.object({
         API_URL: z.string().default('https://api.example.com').describe('API URL'),
       }),
-      run({ env }) {
-        receivedEnv = env
+      run(c) {
+        receivedEnv = c.env
         return { ok: true }
       },
     })
@@ -1300,8 +1300,8 @@ describe('env', () => {
         DEBUG: z.boolean().default(false).describe('Debug mode'),
         PORT: z.number().default(3000).describe('Port'),
       }),
-      run({ env }) {
-        receivedEnv = env
+      run(c) {
+        receivedEnv = c.env
         return { ok: true }
       },
     })

--- a/src/Mcp.test.ts
+++ b/src/Mcp.test.ts
@@ -19,8 +19,8 @@ function createTestCommands() {
     options: z.object({
       upper: z.boolean().default(false).describe('Uppercase output'),
     }),
-    run({ args, options }: any) {
-      const msg = options.upper ? args.message.toUpperCase() : args.message
+    run(c: any) {
+      const msg = c.options.upper ? c.args.message.toUpperCase() : c.args.message
       return { result: msg }
     },
   })
@@ -34,8 +34,8 @@ function createTestCommands() {
         {
           description: 'Say hello',
           args: z.object({ name: z.string().describe('Name to greet') }),
-          run({ args }: any) {
-            return { greeting: `hello ${args.name}` }
+          run(c: any) {
+            return { greeting: `hello ${c.args.name}` }
           },
         },
       ],
@@ -44,8 +44,8 @@ function createTestCommands() {
 
   commands.set('fail', {
     description: 'Always fails',
-    run({ error }: any) {
-      return error({ code: 'BOOM', message: 'it broke' })
+    run(c: any) {
+      return c.error({ code: 'BOOM', message: 'it broke' })
     },
   })
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -19,10 +19,10 @@ const cli = Cli.create('incur', {
     entry: z.string().optional().describe('Entrypoint path (absolute)'),
     output: z.string().optional().describe('Output path (absolute)'),
   }),
-  async run({ options }) {
-    const dir = options.dir ?? '.'
-    const entry = options.entry ?? dir
-    const output = options.output ?? path.join(dir, 'incur.generated.ts')
+  async run(c) {
+    const dir = c.options.dir ?? '.'
+    const entry = c.options.entry ?? dir
+    const output = c.options.output ?? path.join(dir, 'incur.generated.ts')
     await Typegen.generate(entry, output)
     return { dir, entry, output }
   },

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1192,8 +1192,8 @@ describe('root command with subcommands', () => {
     const cli = Cli.create('tool', {
       description: 'A tool with a default action',
       args: z.object({ query: z.string().optional().describe('Search query') }),
-      run({ args }) {
-        return { default: true, query: args.query ?? null }
+      run(c) {
+        return { default: true, query: c.args.query ?? null }
       },
     })
     cli.command('info', {
@@ -1556,9 +1556,9 @@ function createApp() {
         scopes: z.array(z.string()).default([]).describe('OAuth scopes'),
       }),
       alias: { hostname: 'h', web: 'w' },
-      run({ env, options, ok }) {
-        return ok(
-          { hostname: env.AUTH_HOST, scopes: options.scopes },
+      run(c) {
+        return c.ok(
+          { hostname: c.env.AUTH_HOST, scopes: c.options.scopes },
           {
             cta: {
               description: 'Verify your session:',
@@ -1570,15 +1570,15 @@ function createApp() {
     })
     .command('logout', {
       description: 'Log out of the service',
-      run({ ok }) {
-        return ok({ loggedOut: true })
+      run(c) {
+        return c.ok({ loggedOut: true })
       },
     })
     .command('status', {
       description: 'Show authentication status',
       output: z.object({ loggedIn: z.boolean(), hostname: z.string(), user: z.string() }),
-      run({ error }) {
-        return error({
+      run(c) {
+        return c.error({
           code: 'NOT_AUTHENTICATED',
           message: 'Not logged in',
           retryable: false,
@@ -1607,12 +1607,12 @@ function createApp() {
         ),
         total: z.number(),
       }),
-      run({ options, ok }) {
+      run(c) {
         const items = [
           { id: 'p1', name: 'Alpha', archived: false },
           { id: 'p2', name: 'Beta', archived: true },
-        ].filter((p) => options.archived || !p.archived)
-        return ok(
+        ].filter((p) => c.options.archived || !p.archived)
+        return c.ok(
           { items, total: items.length },
           {
             cta: {
@@ -1634,9 +1634,9 @@ function createApp() {
         description: z.string(),
         members: z.array(z.object({ userId: z.string(), role: z.string() })),
       }),
-      run({ args, ok }) {
-        return ok({
-          id: args.id,
+      run(c) {
+        return c.ok({
+          id: c.args.id,
           name: 'Alpha',
           description: 'Main project',
           members: [{ userId: 'u1', role: 'admin' }],
@@ -1653,13 +1653,13 @@ function createApp() {
       alias: { description: 'd' },
 
       output: z.object({ id: z.string(), url: z.string() }),
-      run({ args, ok }) {
-        return ok(
+      run(c) {
+        return c.ok(
           { id: 'p-new', url: 'https://example.com/projects/p-new' },
           {
             cta: {
               commands: [
-                { command: 'project get p-new', description: `View "${args.name}"` },
+                { command: 'project get p-new', description: `View "${c.args.name}"` },
                 'project list',
               ],
             },
@@ -1675,14 +1675,14 @@ function createApp() {
       }),
       alias: { force: 'f' },
 
-      run({ args, options }) {
-        if (!options.force)
+      run(c) {
+        if (!c.options.force)
           throw new Errors.IncurError({
             code: 'CONFIRMATION_REQUIRED',
-            message: `Use --force to delete project ${args.id}`,
+            message: `Use --force to delete project ${c.args.id}`,
             retryable: true,
           })
-        return { deleted: true, id: args.id }
+        return { deleted: true, id: c.args.id }
       },
     })
 
@@ -1705,11 +1705,11 @@ function createApp() {
           options: { branch: 'release', dryRun: true },
         },
       ],
-      run({ args, options, ok }) {
-        return ok({
+      run(c) {
+        return c.ok({
           deployId: 'd-123',
-          url: `https://${args.env}.example.com`,
-          status: options.dryRun ? 'dry-run' : 'pending',
+          url: `https://${c.args.env}.example.com`,
+          status: c.options.dryRun ? 'dry-run' : 'pending',
         })
       },
     })
@@ -1718,16 +1718,16 @@ function createApp() {
       args: z.object({ deployId: z.string().describe('Deployment ID') }),
 
       output: z.object({ deployId: z.string(), status: z.string(), progress: z.number() }),
-      run({ args }) {
-        return { deployId: args.deployId, status: 'running', progress: 75 }
+      run(c) {
+        return { deployId: c.args.deployId, status: 'running', progress: 75 }
       },
     })
     .command('rollback', {
       description: 'Rollback a deployment',
       args: z.object({ deployId: z.string().describe('Deployment ID') }),
 
-      run({ args }) {
-        return { rolledBack: true, deployId: args.deployId }
+      run(c) {
+        return { rolledBack: true, deployId: c.args.deployId }
       },
     })
 
@@ -1736,8 +1736,8 @@ function createApp() {
   const config = Cli.create('config', {
     description: 'Show current configuration',
     args: z.object({ key: z.string().optional().describe('Config key to show') }),
-    run({ args }) {
-      if (args.key) return { key: args.key, value: 'some-value' }
+    run(c) {
+      if (c.args.key) return { key: c.args.key, value: 'some-value' }
       return { apiUrl: 'https://api.example.com', timeout: 30, debug: false }
     },
   })
@@ -1765,10 +1765,10 @@ function createApp() {
       prefix: z.string().default('').describe('Prefix string'),
     }),
     alias: { upper: 'u', prefix: 'p' },
-    run({ args, options }) {
-      const count = args.repeat ?? 1
-      let msg = options.prefix ? `${options.prefix} ${args.message}` : args.message
-      if (options.upper) msg = msg.toUpperCase()
+    run(c) {
+      const count = c.args.repeat ?? 1
+      let msg = c.options.prefix ? `${c.options.prefix} ${c.args.message}` : c.args.message
+      if (c.options.upper) msg = msg.toUpperCase()
       return { result: Array(count).fill(msg) }
     },
   })


### PR DESCRIPTION
Refactors to use `c` ([a la Hono](https://hono.dev/docs/api/context)) instead of destructuring (easier to autocomplete and discover methods/properties)