### PR TITLE
fix: streaming handler ignoring CLI-level and command-level default `format`

### DIFF
--- a/.changeset/streaming-format-default.md
+++ b/.changeset/streaming-format-default.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Fixed streaming handler ignoring CLI-level and command-level default `format`. Previously, `handleStreaming` used only `formatExplicit` to decide between incremental and buffered mode, causing CLI defaults like `{ format: 'json' }` to be ignored in favor of hardcoded `'toon'`.

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -1722,6 +1722,35 @@ describe('outputPolicy', () => {
     expect(piped.output).toContain('step: 1')
   })
 
+  test('streaming respects CLI-level default format json', async () => {
+    const cli = Cli.create('test', { format: 'json' })
+    cli.command('stream', {
+      async *run() {
+        yield { step: 1 }
+        yield { step: 2 }
+      },
+    })
+
+    const { output } = await serve(cli, ['stream'])
+    expect(output).toContain('"step": 1')
+    expect(output).toContain('"step": 2')
+    expect(output).not.toContain('step: 1') // should not be toon format
+  })
+
+  test('streaming respects CLI-level default format jsonl', async () => {
+    const cli = Cli.create('test', { format: 'jsonl' })
+    cli.command('stream', {
+      async *run() {
+        yield { step: 1 }
+        yield { step: 2 }
+      },
+    })
+
+    const { output } = await serve(cli, ['stream'])
+    expect(output).toContain('{"type":"chunk","data":{"step":1}}')
+    expect(output).toContain('{"type":"chunk","data":{"step":2}}')
+  })
+
   test('e2e: realistic multi-level CLI with mixed policies', async () => {
     const cli = Cli.create('tool', { description: 'A deployment tool' })
 

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -1244,8 +1244,8 @@ async function handleStreaming(
 ) {
   // Incremental: no explicit format (default toon), or explicit jsonl
   // Buffered: explicit json/yaml/toon/md
-  const useJsonl = ctx.formatExplicit && ctx.format === 'jsonl'
-  const incremental = useJsonl || !ctx.formatExplicit
+  const useJsonl = ctx.format === 'jsonl'
+  const incremental = useJsonl || (!ctx.formatExplicit && ctx.format === 'toon')
 
   if (incremental) {
     // Incremental output: write each chunk as it arrives
@@ -1280,7 +1280,7 @@ async function handleStreaming(
           }
         }
         if (useJsonl) ctx.writeln(JSON.stringify({ type: 'chunk', data: value }))
-        else if (ctx.renderOutput) ctx.writeln(Formatter.format(value, 'toon'))
+        else if (ctx.renderOutput) ctx.writeln(Formatter.format(value, ctx.format))
       }
 
       // Handle return value — error() or ok() sentinel


### PR DESCRIPTION
Fixes #27