### PR TITLE
chore: tweaks

### DIFF
--- a/.changeset/cta-hash-prefix.md
+++ b/.changeset/cta-hash-prefix.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Added leading `#` to CTA command descriptions for easier copy-paste.

--- a/.changeset/env-section-bottom.md
+++ b/.changeset/env-section-bottom.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Moved environment variables section to bottom of help output.

--- a/.changeset/group-subcommand-fallback.md
+++ b/.changeset/group-subcommand-fallback.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Fixed invalid subcommand in a group falling through to root handler instead of returning `COMMAND_NOT_FOUND`. Added CTA with copyable help command to `COMMAND_NOT_FOUND` errors.

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -138,7 +138,11 @@ describe('serve', () => {
     expect(exitCode).toBe(1)
     expect(output).toMatchInlineSnapshot(`
       "code: COMMAND_NOT_FOUND
-      message: 'nonexistent' is not a command. See 'test --help' for a list of available commands.
+      message: 'nonexistent' is not a command.
+      cta:
+        description: "See available commands:"
+        commands[1]{command}:
+          test --help
       "
     `)
   })
@@ -151,7 +155,10 @@ describe('serve', () => {
     ;(process.stdout as any).isTTY = false
     expect(exitCode).toBe(1)
     expect(output).toMatchInlineSnapshot(`
-      "Error: 'nonexistent' is not a command. See 'test --help' for a list of available commands.
+      "Error: 'nonexistent' is not a command.
+
+      See available commands:
+        test --help
       "
     `)
   })
@@ -165,9 +172,13 @@ describe('serve', () => {
       "ok: false
       error:
         code: COMMAND_NOT_FOUND
-        message: 'nonexistent' is not a command. See 'test --help' for a list of available commands.
+        message: 'nonexistent' is not a command.
       meta:
         command: nonexistent
+        cta:
+          description: "See available commands:"
+          commands[1]{command}:
+            test --help
         duration: <stripped>
       "
     `)
@@ -680,7 +691,11 @@ describe('subcommands', () => {
     expect(exitCode).toBe(1)
     expect(output).toMatchInlineSnapshot(`
       "code: COMMAND_NOT_FOUND
-      message: 'unknown' is not a command. See 'test pr --help' for a list of available commands.
+      message: 'unknown' is not a command.
+      cta:
+        description: "See available commands:"
+        commands[1]{command}:
+          test pr --help
       "
     `)
   })
@@ -697,7 +712,10 @@ describe('subcommands', () => {
     ;(process.stdout as any).isTTY = false
     expect(exitCode).toBe(1)
     expect(output).toMatchInlineSnapshot(`
-      "Error: 'unknown' is not a command. See 'test pr --help' for a list of available commands.
+      "Error: 'unknown' is not a command.
+
+      See available commands:
+        test pr --help
       "
     `)
   })
@@ -1288,6 +1306,21 @@ describe('help', () => {
     expect(output).toContain('no url')
   })
 
+  test('invalid subcommand in group returns COMMAND_NOT_FOUND instead of falling through to root', async () => {
+    const cli = Cli.create('tool', {
+      args: z.object({ url: z.string().describe('URL') }),
+      run: ({ args }) => ({ url: args.url }),
+    })
+    const auth = Cli.create('auth').command('login', { run: () => ({ ok: true }) })
+    cli.command(auth)
+
+    const { output, exitCode } = await serve(cli, ['auth', 'badcmd', '--format', 'json'])
+    expect(exitCode).toBe(1)
+    const parsed = JSON.parse(output)
+    expect(parsed.code).toBe('COMMAND_NOT_FOUND')
+    expect(parsed.message).toContain('badcmd')
+  })
+
   test('--version outputs version string', async () => {
     const cli = Cli.create('tool', { version: '1.2.3' })
     cli.command('ping', { run: () => ({}) })
@@ -1435,15 +1468,15 @@ describe('env', () => {
 
       Usage: test deploy
 
-      Environment Variables:
-        API_TOKEN  Auth token
-        API_URL    API URL (default: https://api.example.com)
-
       Global Options:
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
         --verbose                           Show full output envelope
+
+      Environment Variables:
+        API_TOKEN  Auth token
+        API_URL    API URL (default: https://api.example.com)
       "
     `)
   })

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -704,7 +704,7 @@ async function serveImpl(
 
   // Fall back to root command when no subcommand matches
   const effective =
-    'error' in resolved && options.rootCommand
+    'error' in resolved && options.rootCommand && !resolved.path
       ? { command: options.rootCommand, path: name, rest: filtered }
       : resolved
 
@@ -736,9 +736,14 @@ async function serveImpl(
 
   if ('error' in effective) {
     const helpCmd = effective.path ? `${name} ${effective.path} --help` : `${name} --help`
-    const message = `'${effective.error}' is not a command. See '${helpCmd}' for a list of available commands.`
+    const message = `'${effective.error}' is not a command.`
+    const cta: FormattedCtaBlock = {
+      description: 'See available commands:',
+      commands: [{ command: helpCmd }],
+    }
     if (human && !verbose) {
       writeln(formatHumanError({ code: 'COMMAND_NOT_FOUND', message }))
+      writeln(formatHumanCta(cta))
       exit(1)
       return
     }
@@ -747,6 +752,7 @@ async function serveImpl(
       error: { code: 'COMMAND_NOT_FOUND', message },
       meta: {
         command: effective.error,
+        cta,
         duration: `${Math.round(performance.now() - start)}ms`,
       },
     })
@@ -1200,7 +1206,7 @@ function formatHumanError(error: {
 function formatHumanCta(cta: FormattedCtaBlock): string {
   const lines: string[] = ['', cta.description]
   for (const c of cta.commands) {
-    const desc = c.description ? `  ${c.description}` : ''
+    const desc = c.description ? `  # ${c.description}` : ''
     lines.push(`  ${c.command}${desc}`)
   }
   return lines.join('\n')

--- a/src/Help.ts
+++ b/src/Help.ts
@@ -150,24 +150,6 @@ export function formatCommand(name: string, options: formatCommand.Options = {})
     }
   }
 
-  // Environment Variables
-  if (env) {
-    const entries = envEntries(env)
-    if (entries.length > 0) {
-      lines.push('')
-      lines.push('Environment Variables:')
-      const maxLen = Math.max(...entries.map((e) => e.name.length))
-      for (const entry of entries) {
-        const padding = ' '.repeat(maxLen - entry.name.length)
-        const desc =
-          entry.defaultValue !== undefined
-            ? `${entry.description} (default: ${entry.defaultValue})`
-            : entry.description
-        lines.push(`  ${entry.name}${padding}  ${desc}`)
-      }
-    }
-  }
-
   // Examples
   if (examples && examples.length > 0) {
     lines.push('')
@@ -204,6 +186,24 @@ export function formatCommand(name: string, options: formatCommand.Options = {})
   }
 
   lines.push(...globalOptionsLines(root))
+
+  // Environment Variables
+  if (env) {
+    const entries = envEntries(env)
+    if (entries.length > 0) {
+      lines.push('')
+      lines.push('Environment Variables:')
+      const maxLen = Math.max(...entries.map((e) => e.name.length))
+      for (const entry of entries) {
+        const padding = ' '.repeat(maxLen - entry.name.length)
+        const desc =
+          entry.defaultValue !== undefined
+            ? `${entry.description} (default: ${entry.defaultValue})`
+            : entry.description
+        lines.push(`  ${entry.name}${padding}  ${desc}`)
+      }
+    }
+  }
 
   return lines.join('\n')
 }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -66,7 +66,11 @@ describe('routing', () => {
     expect(exitCode).toBe(1)
     expect(output).toMatchInlineSnapshot(`
       "code: COMMAND_NOT_FOUND
-      message: 'nonexistent' is not a command. See 'app --help' for a list of available commands.
+      message: 'nonexistent' is not a command.
+      cta:
+        description: "See available commands:"
+        commands[1]{command}:
+          app --help
       "
     `)
   })
@@ -77,7 +81,10 @@ describe('routing', () => {
     ;(process.stdout as any).isTTY = false
     expect(exitCode).toBe(1)
     expect(output).toMatchInlineSnapshot(`
-      "Error: 'nonexistent' is not a command. See 'app --help' for a list of available commands.
+      "Error: 'nonexistent' is not a command.
+
+      See available commands:
+        app --help
       "
     `)
   })
@@ -87,7 +94,11 @@ describe('routing', () => {
     expect(exitCode).toBe(1)
     expect(output).toMatchInlineSnapshot(`
       "code: COMMAND_NOT_FOUND
-      message: 'whoami' is not a command. See 'app auth --help' for a list of available commands.
+      message: 'whoami' is not a command.
+      cta:
+        description: "See available commands:"
+        commands[1]{command}:
+          app auth --help
       "
     `)
   })
@@ -97,7 +108,11 @@ describe('routing', () => {
     expect(exitCode).toBe(1)
     expect(output).toMatchInlineSnapshot(`
       "code: COMMAND_NOT_FOUND
-      message: 'nope' is not a command. See 'app project deploy --help' for a list of available commands.
+      message: 'nope' is not a command.
+      cta:
+        description: "See available commands:"
+        commands[1]{command}:
+          app project deploy --help
       "
     `)
   })
@@ -494,10 +509,18 @@ describe('error handling', () => {
       {
         "error": {
           "code": "COMMAND_NOT_FOUND",
-          "message": "'nonexistent' is not a command. See 'app --help' for a list of available commands.",
+          "message": "'nonexistent' is not a command.",
         },
         "meta": {
           "command": "nonexistent",
+          "cta": {
+            "commands": [
+              {
+                "command": "app --help",
+              },
+            ],
+            "description": "See available commands:",
+          },
           "duration": "<stripped>",
         },
         "ok": false,
@@ -1477,15 +1500,15 @@ describe('env', () => {
         --web, -w <boolean>      Open browser (default: false)
         --scopes <array>         OAuth scopes
 
-      Environment Variables:
-        AUTH_TOKEN  Pre-existing auth token
-        AUTH_HOST   Auth server hostname (default: api.example.com)
-
       Global Options:
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
         --verbose                           Show full output envelope
+
+      Environment Variables:
+        AUTH_TOKEN  Pre-existing auth token
+        AUTH_HOST   Auth server hostname (default: api.example.com)
       "
     `)
   })


### PR DESCRIPTION
- Adds leading `#` to CTA command descriptions for easier copy-paste
- Moved environment variables section to bottom of help output.
- Fixes invalid subcommand in a group falling through to root handler instead of returning `COMMAND_NOT_FOUND`.