### PR TITLE
feat: add --schema global option

### DIFF
--- a/.changeset/add-schema-flag.md
+++ b/.changeset/add-schema-flag.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Added `--schema` global option to every command that returns its JSON Schema (args, env, options, output).

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -580,6 +580,121 @@ describe('--llms', () => {
   })
 })
 
+describe('--schema', () => {
+  test('returns command schema in toon format', async () => {
+    const cli = Cli.create('test')
+    cli.command('greet', {
+      args: z.object({ name: z.string().describe('Name to greet') }),
+      options: z.object({ loud: z.boolean().default(false).describe('Shout') }),
+      output: z.object({ message: z.string() }),
+      run(c) {
+        return { message: `hello ${c.args.name}` }
+      },
+    })
+    const { output } = await serve(cli, ['greet', '--schema'])
+    expect(output).toContain('args')
+    expect(output).toContain('options')
+    expect(output).toContain('output')
+  })
+
+  test('returns command schema as JSON', async () => {
+    const cli = Cli.create('test')
+    cli.command('greet', {
+      args: z.object({ name: z.string().describe('Name to greet') }),
+      options: z.object({ loud: z.boolean().default(false).describe('Shout') }),
+      output: z.object({ message: z.string() }),
+      run(c) {
+        return { message: `hello ${c.args.name}` }
+      },
+    })
+    const { output } = await serve(cli, ['greet', '--schema', '--format', 'json'])
+    expect(JSON.parse(output)).toMatchInlineSnapshot(`
+      {
+        "args": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "description": "Name to greet",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+        "options": {
+          "additionalProperties": false,
+          "properties": {
+            "loud": {
+              "default": false,
+              "description": "Shout",
+              "type": "boolean",
+            },
+          },
+          "required": [
+            "loud",
+          ],
+          "type": "object",
+        },
+        "output": {
+          "additionalProperties": false,
+          "properties": {
+            "message": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "message",
+          ],
+          "type": "object",
+        },
+      }
+    `)
+  })
+
+  test('on root command', async () => {
+    const cli = Cli.create('test', {
+      args: z.object({ name: z.string() }),
+      output: z.object({ greeting: z.string() }),
+      run(c) {
+        return { greeting: `hi ${c.args.name}` }
+      },
+    })
+    const { output } = await serve(cli, ['--schema', '--format', 'json'])
+    const parsed = JSON.parse(output)
+    expect(parsed.args).toBeDefined()
+    expect(parsed.output).toBeDefined()
+  })
+
+  test('on unknown command shows error', async () => {
+    const cli = Cli.create('test')
+    cli.command('greet', { run: () => ({}) })
+    const { output, exitCode } = await serve(cli, ['nope', '--schema'])
+    expect(output).toContain("'nope' is not a command")
+    expect(exitCode).toBe(1)
+  })
+
+  test('on group shows available commands', async () => {
+    const cli = Cli.create('test')
+    const pr = Cli.create('pr', { description: 'PR management' }).command('list', {
+      description: 'List PRs',
+      run: () => ({ items: [] }),
+    })
+    cli.command(pr)
+    const { output } = await serve(cli, ['pr', '--schema'])
+    expect(output).toContain('pr')
+    expect(output).toContain('list')
+  })
+
+  test('omits empty schema sections', async () => {
+    const cli = Cli.create('test')
+    cli.command('ping', { run: () => ({ pong: true }) })
+    const { output } = await serve(cli, ['ping', '--schema', '--format', 'json'])
+    expect(JSON.parse(output)).toMatchInlineSnapshot('{}')
+  })
+})
+
 describe('subcommands', () => {
   test('creates a command group with name and description', () => {
     const pr = Cli.create('pr', { description: 'PR management' })
@@ -743,6 +858,7 @@ describe('subcommands', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
       "
     `)
@@ -1179,6 +1295,7 @@ describe('help', () => {
         --help                              Show help
         --llms                              Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
         --version                           Show version
       "
@@ -1213,6 +1330,7 @@ describe('help', () => {
         --help                              Show help
         --llms                              Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
         --version                           Show version
       "
@@ -1242,6 +1360,7 @@ describe('help', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
       "
     `)
@@ -1272,6 +1391,7 @@ describe('help', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
       "
     `)
@@ -1364,6 +1484,7 @@ describe('help', () => {
         --help                              Show help
         --llms                              Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
         --version                           Show version
       "
@@ -1391,6 +1512,7 @@ describe('help', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
       "
     `)
@@ -1482,6 +1604,7 @@ describe('env', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
 
       Environment Variables:
@@ -1516,6 +1639,7 @@ describe('env', () => {
           --format <toon|json|yaml|md|jsonl>  Output format
           --help                              Show help
           --llms                              Print LLM-readable manifest
+          --schema                            Show JSON Schema for a command
           --verbose                           Show full output envelope
 
         Environment Variables:

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -405,6 +405,7 @@ async function serveImpl(
     mcp: mcpFlag,
     help,
     version,
+    schema,
     rest: filtered,
   } = extractBuiltinFlags(argv)
 
@@ -441,7 +442,7 @@ async function serveImpl(
   }
 
   // Skills staleness check (skip for built-in commands)
-  if (!llms && !help && !version) {
+  if (!llms && !schema && !help && !version) {
     const isSkillsAdd =
       filtered[0] === 'skills' || (filtered[0] === name && filtered[1] === 'skills')
     const isMcpAdd = filtered[0] === 'mcp' || (filtered[0] === name && filtered[1] === 'mcp')
@@ -823,6 +824,39 @@ async function serveImpl(
         }),
       )
     }
+    return
+  }
+
+  // --schema: output JSON Schema for a command's args, env, options, output
+  if (schema) {
+    if ('help' in resolved) {
+      writeln(
+        Help.formatRoot(`${name} ${resolved.path}`, {
+          description: resolved.description,
+          commands: collectHelpCommands(resolved.commands),
+        }),
+      )
+      return
+    }
+    if ('error' in resolved) {
+      const parent = resolved.path ? `${name} ${resolved.path}` : name
+      writeln(`Error: '${resolved.error}' is not a command for '${parent}'.`)
+      exit(1)
+      return
+    }
+    if ('fetchGateway' in resolved) {
+      writeln('--schema is not supported for fetch commands.')
+      exit(1)
+      return
+    }
+    const cmd = resolved.command
+    const format = formatExplicit ? formatFlag : 'toon'
+    const result: Record<string, unknown> = {}
+    if (cmd.args) result.args = Schema.toJsonSchema(cmd.args)
+    if (cmd.env) result.env = Schema.toJsonSchema(cmd.env)
+    if (cmd.options) result.options = Schema.toJsonSchema(cmd.options)
+    if (cmd.output) result.output = Schema.toJsonSchema(cmd.output)
+    writeln(Formatter.format(result, format))
     return
   }
 
@@ -1379,6 +1413,7 @@ function extractBuiltinFlags(argv: string[]) {
   let mcp = false
   let help = false
   let version = false
+  let schema = false
   let format: Formatter.Format = 'toon'
   let formatExplicit = false
   let filterOutput: string | undefined
@@ -1391,6 +1426,7 @@ function extractBuiltinFlags(argv: string[]) {
     else if (token === '--mcp') mcp = true
     else if (token === '--help' || token === '-h') help = true
     else if (token === '--version') version = true
+    else if (token === '--schema') schema = true
     else if (token === '--json') {
       format = 'json'
       formatExplicit = true
@@ -1404,7 +1440,7 @@ function extractBuiltinFlags(argv: string[]) {
     } else rest.push(token)
   }
 
-  return { verbose, format, formatExplicit, filterOutput, llms, mcp, help, version, rest }
+  return { verbose, format, formatExplicit, filterOutput, llms, mcp, help, version, schema, rest }
 }
 
 /** @internal Collects immediate child commands/groups for help output. */

--- a/src/Help.test.ts
+++ b/src/Help.test.ts
@@ -29,6 +29,7 @@ describe('formatCommand', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope"
     `)
   })
@@ -47,6 +48,7 @@ describe('formatCommand', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope"
     `)
   })
@@ -72,6 +74,7 @@ describe('formatCommand', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope"
     `)
   })
@@ -114,6 +117,7 @@ describe('formatRoot', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope"
     `)
   })
@@ -135,6 +139,7 @@ describe('formatRoot', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope"
     `)
   })
@@ -160,6 +165,7 @@ describe('formatRoot', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope"
     `)
   })
@@ -185,6 +191,7 @@ describe('formatRoot', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope"
     `)
   })

--- a/src/Help.ts
+++ b/src/Help.ts
@@ -331,6 +331,7 @@ function globalOptionsLines(root = false): string[] {
     { flag: '--help', desc: 'Show help' },
     { flag: '--llms', desc: 'Print LLM-readable manifest' },
     ...(root ? [{ flag: '--mcp', desc: 'Start as MCP stdio server' }] : []),
+    { flag: '--schema', desc: 'Show JSON Schema for a command' },
     { flag: '--verbose', desc: 'Show full output envelope' },
     ...(root ? [{ flag: '--version', desc: 'Show version' }] : []),
   ]

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -850,6 +850,7 @@ describe('help', () => {
         --help                              Show help
         --llms                              Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
         --version                           Show version
       "
@@ -879,6 +880,7 @@ describe('help', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
       "
     `)
@@ -902,6 +904,7 @@ describe('help', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
       "
     `)
@@ -924,6 +927,7 @@ describe('help', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
       "
     `)
@@ -952,6 +956,7 @@ describe('help', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
       "
     `)
@@ -1352,6 +1357,7 @@ describe('root command with subcommands', () => {
         --help                              Show help
         --llms                              Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
         --version                           Show version
       "
@@ -1524,6 +1530,7 @@ describe('env', () => {
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
         --llms                              Print LLM-readable manifest
+        --schema                            Show JSON Schema for a command
         --verbose                           Show full output envelope
 
       Environment Variables:


### PR DESCRIPTION
## Summary

Adds a `--schema` global option that dumps the JSON Schema for any command's args, env, options, and output. Agents can introspect what a command accepts at runtime without loading skill files.

## Changes

- Added `--schema` boolean to `extractBuiltinFlags` in `Cli.ts`
- Schema handler resolves the command, builds JSON Schema from Zod schemas via `Schema.toJsonSchema`, outputs via `Formatter.format`
- Defaults to TOON; respects `--format` / `--json`
- Groups fall back to help output; fetch gateways return an error; unknown commands error with exit 1
- Added `--schema` to global options in `Help.ts`

## Testing

6 new tests: toon output, JSON snapshot, root command, unknown command error, group fallback, empty schema. All 603 tests pass.

```
pnpm test -- --run
```

Prompted by: tmm