### PR TITLE
feat: structured exit codes

### DIFF
--- a/.changeset/exit-codes.md
+++ b/.changeset/exit-codes.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Added optional exitCode to c.error() and IncurError, allowing CLI authors to control the process exit code. Defaults to 1 when omitted (backward compatible).

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -251,6 +251,18 @@ test('middleware error() returns never', () => {
   })
 })
 
+test('c.error() accepts optional exitCode', () => {
+  Cli.create('test').command('fail', {
+    run(c) {
+      // with exitCode
+      c.error({ code: 'ERR', message: 'fail', exitCode: 10 })
+      // without exitCode
+      c.error({ code: 'ERR', message: 'fail' })
+      return {}
+    },
+  })
+})
+
 test('env is typed in per-command middleware', () => {
   Cli.create('test', {
     env: z.object({ API_TOKEN: z.string() }),

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -2413,6 +2413,88 @@ test('streaming: generator returns error in buffered mode', async () => {
   expect(output).toContain('RET_ERR')
 })
 
+test('c.error({ exitCode }) uses custom exit code', async () => {
+  const cli = Cli.create('test')
+  cli.command('fail', {
+    run(c) {
+      return c.error({ code: 'AUTH', message: 'not authed', exitCode: 10 })
+    },
+  })
+
+  const { output, exitCode } = await serve(cli, ['fail'])
+  expect(exitCode).toBe(10)
+  expect(output).toMatchInlineSnapshot(`
+    "code: AUTH
+    message: not authed
+    "
+  `)
+})
+
+test('c.error() without exitCode defaults to 1', async () => {
+  const cli = Cli.create('test')
+  cli.command('fail', {
+    run(c) {
+      return c.error({ code: 'BAD', message: 'fail' })
+    },
+  })
+
+  const { output, exitCode } = await serve(cli, ['fail'])
+  expect(exitCode).toBe(1)
+  expect(output).toMatchInlineSnapshot(`
+    "code: BAD
+    message: fail
+    "
+  `)
+})
+
+test('middleware c.error({ exitCode }) uses custom exit code', async () => {
+  const cli = Cli.create('test')
+  cli.use((c) => {
+    return c.error({ code: 'MW_ERR', message: 'blocked', exitCode: 42 })
+  })
+  cli.command('anything', { run: () => ({}) })
+
+  const { output, exitCode } = await serve(cli, ['anything'])
+  expect(exitCode).toBe(42)
+  expect(output).toMatchInlineSnapshot(`
+    "code: MW_ERR
+    message: blocked
+    "
+  `)
+})
+
+test('thrown IncurError with exitCode uses custom exit code', async () => {
+  const cli = Cli.create('test')
+  cli.command('fail', {
+    run() {
+      throw new Errors.IncurError({ code: 'RATE_LIMITED', message: 'too fast', exitCode: 99 })
+    },
+  })
+
+  const { output, exitCode } = await serve(cli, ['fail'])
+  expect(exitCode).toBe(99)
+  expect(output).toMatchInlineSnapshot(`
+    "code: RATE_LIMITED
+    message: too fast
+    retryable: false
+    "
+  `)
+})
+
+test('streaming: c.error({ exitCode }) in yield uses custom exit code', async () => {
+  const cli = Cli.create('test')
+  cli.command('fail', {
+    async *run(c) {
+      yield { step: 1 }
+      yield c.error({ code: 'STREAM_ERR', message: 'mid-stream', exitCode: 77 })
+    },
+  })
+
+  const { output, exitCode } = await serve(cli, ['fail', '--format', 'jsonl'])
+  expect(exitCode).toBe(77)
+  expect(output).toContain('STREAM_ERR')
+})
+
 test('deprecated short flag emits warning', async () => {
   const cli = Cli.create('app').command('deploy', {
     options: z.object({

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -333,6 +333,7 @@ export declare namespace create {
           error: (options: {
             code: string
             cta?: CtaBlock | undefined
+            exitCode?: number | undefined
             message: string
             retryable?: boolean | undefined
           }) => never
@@ -973,7 +974,7 @@ async function serveImpl(
       const cliEnv = options.envSchema ? Parser.parseEnv(options.envSchema, options.env ?? process.env) : {}
       if (fetchMiddleware.length > 0) {
         const varsMap: Record<string, unknown> = options.vars ? options.vars.parse({}) : {}
-        const errorFn = (opts: { code: string; message: string; retryable?: boolean | undefined; cta?: CtaBlock | undefined }): never =>
+        const errorFn = (opts: { code: string; exitCode?: number | undefined; message: string; retryable?: boolean | undefined; cta?: CtaBlock | undefined }): never =>
           ({ [sentinel]: 'error', ...opts }) as never
         const mwCtx: MiddlewareContext = {
           agent: !human,
@@ -987,13 +988,14 @@ async function serveImpl(
         }
         const handleMwSentinel = (result: unknown) => {
           if (!isSentinel(result) || result[sentinel] !== 'error') return
-          const cta = formatCtaBlock(name, result.cta)
+          const err = result as ErrorResult
+          const cta = formatCtaBlock(name, err.cta)
           write({
             ok: false,
-            error: { code: result.code, message: result.message, ...(result.retryable !== undefined ? { retryable: result.retryable } : undefined) },
+            error: { code: err.code, message: err.message, ...(err.retryable !== undefined ? { retryable: err.retryable } : undefined) },
             meta: { command: path, duration: `${Math.round(performance.now() - start)}ms`, ...(cta ? { cta } : undefined) },
           })
-          exit(1)
+          exit(err.exitCode ?? 1)
         }
         const composed = fetchMiddleware.reduceRight(
           (next: () => Promise<void>, mw) => async () => { handleMwSentinel(await mw(mwCtx, next)) },
@@ -1012,7 +1014,7 @@ async function serveImpl(
         },
         meta: { command: path, duration: `${Math.round(performance.now() - start)}ms` },
       })
-      exit(1)
+      exit(error instanceof IncurError ? (error.exitCode ?? 1) : 1)
     }
     return
   }
@@ -1053,6 +1055,7 @@ async function serveImpl(
     }
     const errorFn = (opts: {
       code: string
+      exitCode?: number | undefined
       message: string
       retryable?: boolean | undefined
       cta?: CtaBlock | undefined
@@ -1105,12 +1108,13 @@ async function serveImpl(
           },
         })
       } else {
+        const err = awaited as ErrorResult
         write({
           ok: false,
           error: {
-            code: awaited.code,
-            message: awaited.message,
-            ...(awaited.retryable !== undefined ? { retryable: awaited.retryable } : undefined),
+            code: err.code,
+            message: err.message,
+            ...(err.retryable !== undefined ? { retryable: err.retryable } : undefined),
           },
           meta: {
             command: path,
@@ -1118,7 +1122,7 @@ async function serveImpl(
             ...(cta ? { cta } : undefined),
           },
         })
-        exit(1)
+        exit(err.exitCode ?? 1)
       }
     } else {
       write({
@@ -1138,6 +1142,7 @@ async function serveImpl(
     if (allMiddleware.length > 0) {
       const errorFn = (opts: {
         code: string
+        exitCode?: number | undefined
         message: string
         retryable?: boolean | undefined
         cta?: CtaBlock | undefined
@@ -1158,13 +1163,14 @@ async function serveImpl(
       }
       const handleMwSentinel = (result: unknown) => {
         if (!isSentinel(result) || result[sentinel] !== 'error') return
-        const cta = formatCtaBlock(name, result.cta)
+        const err = result as ErrorResult
+        const cta = formatCtaBlock(name, err.cta)
         write({
           ok: false,
           error: {
-            code: result.code,
-            message: result.message,
-            ...(result.retryable !== undefined ? { retryable: result.retryable } : undefined),
+            code: err.code,
+            message: err.message,
+            ...(err.retryable !== undefined ? { retryable: err.retryable } : undefined),
           },
           meta: {
             command: path,
@@ -1172,7 +1178,7 @@ async function serveImpl(
             ...(cta ? { cta } : undefined),
           },
         })
-        exit(1)
+        exit(err.exitCode ?? 1)
       }
       const composed = allMiddleware.reduceRight(
         (next: () => Promise<void>, mw) => async () => {
@@ -1211,7 +1217,7 @@ async function serveImpl(
     }
 
     write(errorOutput)
-    exit(1)
+    exit(error instanceof IncurError ? (error.exitCode ?? 1) : 1)
   }
 }
 
@@ -1508,6 +1514,7 @@ type ErrorResult = {
   code: string
   message: string
   retryable?: boolean | undefined
+  exitCode?: number | undefined
   cta?: CtaBlock | undefined
 }
 
@@ -1613,7 +1620,7 @@ async function handleStreaming(
                 }),
               )
             else ctx.writeln(formatHumanError({ code: tagged.code, message: tagged.message }))
-            ctx.exit(1)
+            ctx.exit(tagged.exitCode ?? 1)
             return
           }
         }
@@ -1637,7 +1644,7 @@ async function handleStreaming(
             }),
           )
         else ctx.writeln(formatHumanError({ code: err.code, message: err.message }))
-        ctx.exit(1)
+        ctx.exit(err.exitCode ?? 1)
         return
       }
 
@@ -1678,7 +1685,7 @@ async function handleStreaming(
             message: error instanceof Error ? error.message : String(error),
           }),
         )
-      ctx.exit(1)
+      ctx.exit(error instanceof IncurError ? (error.exitCode ?? 1) : 1)
     }
   } else {
     // Buffered output: collect all chunks, write as single value
@@ -1706,7 +1713,7 @@ async function handleStreaming(
                 duration: `${Math.round(performance.now() - ctx.start)}ms`,
               },
             })
-            ctx.exit(1)
+            ctx.exit(tagged.exitCode ?? 1)
             return
           }
         }
@@ -1727,7 +1734,7 @@ async function handleStreaming(
             duration: `${Math.round(performance.now() - ctx.start)}ms`,
           },
         })
-        ctx.exit(1)
+        ctx.exit(err.exitCode ?? 1)
         return
       }
 
@@ -1757,7 +1764,7 @@ async function handleStreaming(
           duration: `${Math.round(performance.now() - ctx.start)}ms`,
         },
       })
-      ctx.exit(1)
+      ctx.exit(error instanceof IncurError ? (error.exitCode ?? 1) : 1)
     }
   }
 }
@@ -2062,6 +2069,7 @@ type CommandDefinition<
     error: (options: {
       code: string
       cta?: CtaBlock | undefined
+      exitCode?: number | undefined
       message: string
       retryable?: boolean | undefined
     }) => never

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -41,12 +41,15 @@ export class IncurError extends BaseError {
   hint: string | undefined
   /** Whether the operation can be retried. */
   retryable: boolean
+  /** Process exit code. When set, `serve()` uses this instead of `1`. */
+  exitCode: number | undefined
 
   constructor(options: IncurError.Options) {
     super(options.message, options.cause ? { cause: options.cause } : undefined)
     this.code = options.code
     this.hint = options.hint
     this.retryable = options.retryable ?? false
+    this.exitCode = options.exitCode
   }
 }
 
@@ -61,6 +64,8 @@ export declare namespace IncurError {
     hint?: string | undefined
     /** Whether the operation can be retried. Defaults to `false`. */
     retryable?: boolean | undefined
+    /** Process exit code. When set, `serve()` uses this instead of `1`. */
+    exitCode?: number | undefined
     /** The underlying cause. */
     cause?: Error | undefined
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,6 +35,7 @@ export type Context<
   error: (options: {
     code: string
     cta?: CtaBlock | undefined
+    exitCode?: number | undefined
     message: string
     retryable?: boolean | undefined
   }) => never


### PR DESCRIPTION
## Summary

- Adds optional `exitCode` to `c.error()` (commands + middleware) and `IncurError`
- When set, `serve()` uses it as the process exit code instead of `1`
- Fully backward compatible — omitting `exitCode` preserves current `exit(1)` behavior

## Motivation

incur currently calls `exit(1)` for every error. CLI consumers (scripts, CI/CD, wrappers) can't distinguish error types without parsing stderr. This lets authors assign semantic exit codes so callers can branch on them:

```sh
mycli deploy || code=$?
if [ $code -eq 10 ]; then
  echo "Auth error"
elif [ $code -eq 42 ]; then
  sleep 5 && mycli deploy  # retry
fi
```

## API

```ts
// command
c.error({ code: 'NOT_AUTHENTICATED', message: '...', exitCode: 10 })

// middleware
c.error({ code: 'RATE_LIMITED', message: '...', exitCode: 42 })

// thrown error
throw new IncurError({ code: 'RATE_LIMITED', message: '...', exitCode: 42 })
```

## What's unchanged

- `ValidationError` / `ParseError` — still `exit(1)`, no `exitCode` field
- `COMMAND_NOT_FOUND` and internal errors — still `exit(1)`
- Output envelope shape — `exitCode` is process-level, not serialized

## Test plan

- [x] `c.error({ exitCode: N })` calls `exit(N)` in commands
- [x] `c.error()` without `exitCode` calls `exit(1)`
- [x] Middleware `c.error({ exitCode })` works
- [x] Thrown `IncurError` with `exitCode` works
- [x] Streaming `yield c.error({ exitCode })` works
- [x] Type test: `exitCode` accepted in `c.error()` options