### PR TITLE
feat: `cli.fetch`

### DIFF
--- a/.changeset/cli-fetch.md
+++ b/.changeset/cli-fetch.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Added `cli.fetch` to expose CLI as a standard Fetch API handler

--- a/README.md
+++ b/README.md
@@ -325,6 +325,60 @@ $ my-cli api createUser --name Bob
 # → name: Bob
 ```
 
+### Serve CLIs as APIs
+
+The inverse of mounting — expose your CLI as a standard Fetch API handler with `cli.fetch`. Works with Bun, Cloudflare Workers, Deno, Hono, and anything that accepts `(req: Request) => Response`.
+
+```ts
+import { Cli, z } from 'incur'
+
+const cli = Cli.create('my-cli', { version: '1.0.0' })
+  .command('users', {
+    args: z.object({ id: z.coerce.number().optional() }),
+    options: z.object({ limit: z.coerce.number().default(10) }),
+    run(c) {
+      if (c.args.id) return { id: c.args.id, name: 'Alice' }
+      return { users: [{ id: 1, name: 'Alice' }], limit: c.options.limit }
+    },
+  })
+
+Bun.serve(cli) // Bun
+Deno.serve(cli.fetch) // Deno
+export default cli // Cloudflare Workers
+app.all('*', c => cli.fetch(c.request)) // Elysia
+app.use(c => cli.fetch(c.req.raw)) // Hono
+export const GET = cli.fetch // Next.js
+export const POST = cli.fetch // Next.js
+```
+
+Path segments map to commands and positional args, query params to options (GET), and JSON body to options (POST):
+
+```
+GET  /users?limit=5    → my-cli users --limit 5
+GET  /users/42         → my-cli users 42
+POST /users { "name": "Bob" }  → my-cli users --name Bob
+```
+
+Responses use the same JSON envelope as `--verbose --format json`:
+
+```json
+{ "ok": true, "data": { "users": [...] }, "meta": { "command": "users", "duration": "3ms" } }
+```
+
+Async generator commands stream as NDJSON (`application/x-ndjson`). Middleware runs the same as in `serve()`.
+
+#### MCP over HTTP
+
+The `fetch` handler automatically exposes an MCP endpoint at `/mcp`. Agents can discover and call your CLI's commands as MCP tools over HTTP — no stdio required:
+
+```
+POST /mcp  { "jsonrpc": "2.0", "method": "initialize", ... }
+POST /mcp  { "jsonrpc": "2.0", "method": "tools/list", ... }
+POST /mcp  { "jsonrpc": "2.0", "method": "tools/call", "params": { "name": "users", ... } }
+```
+
+Non-`/mcp` paths continue routing to the command API as usual.
+
 ## Walkthrough
 
 ### Agent discovery

--- a/SKILL.md
+++ b/SKILL.md
@@ -217,6 +217,65 @@ my-cli api --help                  # shows typed subcommands
 
 Works with any `(Request) => Response` handler — Hono, Elysia, etc. Specs from `@hono/zod-openapi` are supported directly.
 
+### Serve CLI as Fetch API
+
+Expose your CLI as a standard Fetch API handler with `cli.fetch`. Works with Bun, Cloudflare Workers, Deno, Hono, and anything that accepts `(req: Request) => Response`.
+
+```ts
+import { Cli, z } from 'incur'
+
+const cli = Cli.create('my-cli', { version: '1.0.0' })
+  .command('users', {
+    args: z.object({ id: z.coerce.number().optional() }),
+    options: z.object({ limit: z.coerce.number().default(10) }),
+    run(c) {
+      if (c.args.id) return { id: c.args.id, name: 'Alice' }
+      return { users: [{ id: 1, name: 'Alice' }], limit: c.options.limit }
+    },
+  })
+```
+
+```ts
+Bun.serve(cli) // Bun
+Deno.serve(cli.fetch) // Deno
+export default cli // Cloudflare Workers
+app.all('*', c => cli.fetch(c.request)) // Elysia
+app.use(c => cli.fetch(c.req.raw)) // Hono
+export const GET = cli.fetch // Next.js
+export const POST = cli.fetch
+```
+
+Request mapping:
+
+| HTTP | CLI equivalent |
+|------|---------------|
+| `GET /users?limit=5` | `my-cli users --limit 5` |
+| `GET /users/42` | `my-cli users 42` (positional arg) |
+| `POST /users` with JSON body | `my-cli users --name Bob` |
+| `GET /` | root command (or 404) |
+
+Responses are JSON envelopes: `{ "ok": true, "data": { ... }, "meta": { "command": "users", "duration": "3ms" } }`.
+
+Error status codes: 400 for validation errors, 404 for unknown commands, 500 for thrown errors.
+
+Async generator commands stream as NDJSON (`application/x-ndjson`). Middleware runs the same as `serve()`.
+
+#### Fetch gateways
+
+If a resolved command is a fetch gateway (`.command('api', { fetch })`), the request is forwarded to the nested handler.
+
+#### MCP over HTTP
+
+The fetch handler exposes an MCP endpoint at `/mcp`. Agents can discover and call commands as MCP tools over HTTP:
+
+```
+POST /mcp  { "jsonrpc": "2.0", "method": "initialize", ... }
+POST /mcp  { "jsonrpc": "2.0", "method": "tools/list", ... }
+POST /mcp  { "jsonrpc": "2.0", "method": "tools/call", "params": { "name": "users", ... } }
+```
+
+The MCP server is initialized lazily on the first `/mcp` request. Non-`/mcp` paths route to the command API as usual.
+
 ## Arguments & Options
 
 All schemas use Zod. Arguments are positional (assigned by schema key order). Options are named flags.
@@ -846,6 +905,14 @@ await cli.serve(['install', 'express', '--json'], {
 | `stdout` | `(s: string) => void`                 | Override stdout writer         |
 | `exit`   | `(code: number) => void`              | Override exit handler          |
 | `env`    | `Record<string, string \| undefined>` | Override environment variables |
+
+### `cli.fetch(req: Request): Promise<Response>`
+
+Expose the CLI as a Fetch API handler. See [Serve CLI as Fetch API](#serve-cli-as-fetch-api) for full details.
+
+```ts
+Bun.serve(cli)
+```
 
 ## Streaming
 

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -2928,3 +2928,480 @@ describe('--filter-output', () => {
     expect(parsed).toEqual({ name: 'alice', age: 30 })
   })
 })
+
+async function fetchJson(cli: Cli.Cli<any, any, any>, req: Request) {
+  const res = await cli.fetch(req)
+  const body = await res.json()
+  body.meta.duration = '<stripped>'
+  return { status: res.status, body }
+}
+
+describe('fetch', () => {
+  test('GET /health → 200', async () => {
+    const cli = Cli.create('test')
+    cli.command('health', { run: () => ({ ok: true }) })
+    expect(await fetchJson(cli, new Request('http://localhost/health'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "ok": true,
+          },
+          "meta": {
+            "command": "health",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('GET /unknown → 404', async () => {
+    const cli = Cli.create('test')
+    cli.command('health', { run: () => ({}) })
+    expect(await fetchJson(cli, new Request('http://localhost/unknown'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "COMMAND_NOT_FOUND",
+            "message": "'unknown' is not a command for 'test'.",
+          },
+          "meta": {
+            "command": "unknown",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 404,
+      }
+    `)
+  })
+
+  test('GET / with root command → 200', async () => {
+    const cli = Cli.create('test', { run: () => ({ root: true }) })
+    expect(await fetchJson(cli, new Request('http://localhost/'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "root": true,
+          },
+          "meta": {
+            "command": "test",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('GET / without root command → 404', async () => {
+    const cli = Cli.create('test')
+    cli.command('health', { run: () => ({}) })
+    expect(await fetchJson(cli, new Request('http://localhost/'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "COMMAND_NOT_FOUND",
+            "message": "No root command defined.",
+          },
+          "meta": {
+            "command": "/",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 404,
+      }
+    `)
+  })
+
+  test('GET search params → options', async () => {
+    const cli = Cli.create('test')
+    cli.command('users', {
+      options: z.object({ limit: z.coerce.number().default(10) }),
+      run: (c) => ({ limit: c.options.limit }),
+    })
+    expect(await fetchJson(cli, new Request('http://localhost/users?limit=5'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "limit": 5,
+          },
+          "meta": {
+            "command": "users",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('POST body → options', async () => {
+    const cli = Cli.create('test')
+    cli.command('users', {
+      options: z.object({ name: z.string() }),
+      run: (c) => ({ created: true, name: c.options.name }),
+    })
+    const req = new Request('http://localhost/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Bob' }),
+    })
+    expect(await fetchJson(cli, req)).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "created": true,
+            "name": "Bob",
+          },
+          "meta": {
+            "command": "users",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('trailing path segments → positional args', async () => {
+    const cli = Cli.create('test')
+    cli.command('users', {
+      args: z.object({ id: z.coerce.number() }),
+      run: (c) => ({ id: c.args.id }),
+    })
+    expect(await fetchJson(cli, new Request('http://localhost/users/42'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "id": 42,
+          },
+          "meta": {
+            "command": "users",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('nested command resolution', async () => {
+    const sub = Cli.create('users')
+    sub.command('list', { run: () => ({ users: [] }) })
+    const cli = Cli.create('test')
+    cli.command(sub)
+    expect(await fetchJson(cli, new Request('http://localhost/users/list'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "users": [],
+          },
+          "meta": {
+            "command": "users list",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('validation error → 400', async () => {
+    const cli = Cli.create('test')
+    cli.command('users', {
+      args: z.object({ id: z.coerce.number() }),
+      run: (c) => ({ id: c.args.id }),
+    })
+    const { status, body } = await fetchJson(cli, new Request('http://localhost/users'))
+    expect(status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  test('thrown error → 500', async () => {
+    const cli = Cli.create('test')
+    cli.command('fail', {
+      run() {
+        throw new Error('boom')
+      },
+    })
+    expect(await fetchJson(cli, new Request('http://localhost/fail'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "UNKNOWN",
+            "message": "boom",
+          },
+          "meta": {
+            "command": "fail",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 500,
+      }
+    `)
+  })
+
+  test('async generator → NDJSON streaming response', async () => {
+    const cli = Cli.create('test')
+    cli.command('stream', {
+      async *run() {
+        yield { progress: 1 }
+        yield { progress: 2 }
+        return { done: true }
+      },
+    })
+    const res = await cli.fetch(new Request('http://localhost/stream'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('application/x-ndjson')
+    const text = await res.text()
+    const lines = text.trim().split('\n').map((l) => JSON.parse(l))
+    expect(lines).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {
+            "progress": 1,
+          },
+          "type": "chunk",
+        },
+        {
+          "data": {
+            "progress": 2,
+          },
+          "type": "chunk",
+        },
+        {
+          "meta": {
+            "command": "stream",
+          },
+          "ok": true,
+          "type": "done",
+        },
+      ]
+    `)
+  })
+
+  test('middleware sets var → command sees it', async () => {
+    const cli = Cli.create('test', {
+      vars: z.object({ user: z.string().default('anonymous') }),
+    })
+    cli.use(async (c, next) => {
+      c.set('user', 'alice')
+      await next()
+    })
+    cli.command('whoami', {
+      run: (c) => ({ user: c.var.user }),
+    })
+    expect(await fetchJson(cli, new Request('http://localhost/whoami'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "user": "alice",
+          },
+          "meta": {
+            "command": "whoami",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('middleware error → error response', async () => {
+    const cli = Cli.create('test')
+    cli.use((c) => {
+      c.error({ code: 'UNAUTHORIZED', message: 'not allowed' })
+    })
+    cli.command('secret', { run: () => ({ secret: true }) })
+    expect(await fetchJson(cli, new Request('http://localhost/secret'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "UNAUTHORIZED",
+            "message": "not allowed",
+          },
+          "meta": {
+            "command": "secret",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 500,
+      }
+    `)
+  })
+
+  test('fetch gateway → forwards request', async () => {
+    const handler = (req: Request) => {
+      const url = new URL(req.url)
+      return new Response(JSON.stringify({ path: url.pathname }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    const cli = Cli.create('test')
+    cli.command('api', { fetch: handler })
+    const res = await cli.fetch(new Request('http://localhost/api/users/list'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchInlineSnapshot(`
+      {
+        "path": "/api/users/list",
+      }
+    `)
+  })
+
+  describe('mcp over http', () => {
+    function mcpCli() {
+      const cli = Cli.create('test', { version: '1.0.0' })
+      cli.command('greet', {
+        description: 'Greet someone',
+        args: z.object({ name: z.string() }),
+        run: (c) => ({ message: `hello ${c.args.name}` }),
+      })
+      cli.command('ping', {
+        description: 'Ping',
+        run: () => ({ pong: true }),
+      })
+      return cli
+    }
+
+    async function mcpRequest(cli: Cli.Cli<any, any, any>, body: unknown, sessionId?: string) {
+      const headers: Record<string, string> = { 'content-type': 'application/json', accept: 'application/json, text/event-stream' }
+      if (sessionId) headers['mcp-session-id'] = sessionId
+      return cli.fetch(
+        new Request('http://localhost/mcp', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+        }),
+      )
+    }
+
+    async function initSession(cli: Cli.Cli<any, any, any>) {
+      const res = await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      })
+      const sessionId = res.headers.get('mcp-session-id')
+      const body = await res.json()
+      // Send initialized notification
+      await mcpRequest(cli, { jsonrpc: '2.0', method: 'notifications/initialized' }, sessionId!)
+      return { sessionId: sessionId!, body }
+    }
+
+    test('POST /mcp with initialize → valid MCP response', async () => {
+      const cli = mcpCli()
+      const res = await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect({
+        serverInfo: body.result.serverInfo,
+        hasTools: 'tools' in (body.result.capabilities ?? {}),
+      }).toMatchInlineSnapshot(`
+        {
+          "hasTools": true,
+          "serverInfo": {
+            "name": "test",
+            "version": "1.0.0",
+          },
+        }
+      `)
+    })
+
+    test('POST /mcp with tools/list → returns registered tools', async () => {
+      const cli = mcpCli()
+      const { sessionId } = await initSession(cli)
+      const res = await mcpRequest(
+        cli,
+        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+        sessionId,
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      const tools = body.result.tools.map((t: any) => ({
+        name: t.name,
+        description: t.description,
+        hasInputSchema: Object.keys(t.inputSchema?.properties ?? {}).length > 0,
+      }))
+      expect(tools).toMatchInlineSnapshot(`
+        [
+          {
+            "description": "Greet someone",
+            "hasInputSchema": true,
+            "name": "greet",
+          },
+          {
+            "description": "Ping",
+            "hasInputSchema": false,
+            "name": "ping",
+          },
+        ]
+      `)
+    })
+
+    test('POST /mcp with tools/call → executes command', async () => {
+      const cli = mcpCli()
+      const { sessionId } = await initSession(cli)
+      const res = await mcpRequest(
+        cli,
+        {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: { name: 'greet', arguments: { name: 'world' } },
+        },
+        sessionId,
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect({
+        isError: body.result.isError,
+        content: JSON.parse(body.result.content[0].text),
+      }).toMatchInlineSnapshot(`
+        {
+          "content": {
+            "message": "hello world",
+          },
+          "isError": undefined,
+        }
+      `)
+    })
+
+    test('non-/mcp paths still route to command API', async () => {
+      const cli = mcpCli()
+      const { body } = await fetchJson(cli, new Request('http://localhost/ping'))
+      expect(body.data).toMatchInlineSnapshot(`
+        {
+          "pong": true,
+        }
+      `)
+    })
+  })
+})

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -71,6 +71,8 @@ export type Cli<
   env: env
   /** The name of the CLI application. */
   name: string
+  /** Handles an incoming HTTP request, resolves the matching command, and returns a JSON Response. */
+  fetch(req: Request): Promise<Response>
   /** Parses argv, runs the matched command, and writes the output envelope to stdout. */
   serve(argv?: string[], options?: serve.Options): Promise<void>
   /** Registers middleware that runs around every command. */
@@ -187,6 +189,7 @@ export function create(
   const commands = new Map<string, CommandEntry>()
   const middlewares: MiddlewareHandler[] = []
   const pending: Promise<void>[] = []
+  const mcpHandler = createMcpHttpHandler(name, def.version ?? '0.0.0')
 
   const cli: Cli = {
     name,
@@ -240,6 +243,16 @@ export function create(
         ...(subMiddlewares?.length ? { middlewares: subMiddlewares } : undefined),
       })
       return cli
+    },
+
+    async fetch(req: Request) {
+      if (pending.length > 0) await Promise.all(pending)
+      return fetchImpl(name, commands, req, {
+        mcpHandler,
+        middlewares,
+        rootCommand: rootDef,
+        vars: def.vars,
+      })
     },
 
     async serve(argv = process.argv.slice(2), serveOptions: serve.Options = {}) {
@@ -1253,6 +1266,272 @@ async function serveImpl(
     write(errorOutput)
     exit(error instanceof IncurError ? (error.exitCode ?? 1) : 1)
   }
+}
+
+/** @internal Options for fetchImpl. */
+declare namespace fetchImpl {
+  type Options = {
+    mcpHandler?: ((req: Request, commands: Map<string, CommandEntry>) => Promise<Response>) | undefined
+    middlewares?: MiddlewareHandler[] | undefined
+    rootCommand?: CommandDefinition<any, any, any> | undefined
+    vars?: z.ZodObject<any> | undefined
+  }
+}
+
+/** @internal Creates a lazy MCP HTTP handler scoped to a CLI instance. */
+function createMcpHttpHandler(name: string, version: string) {
+  let transport: any
+
+  return async (req: Request, commands: Map<string, CommandEntry>): Promise<Response> => {
+    if (!transport) {
+      const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js')
+      const { WebStandardStreamableHTTPServerTransport } = await import(
+        '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+      )
+
+      const server = new McpServer({ name, version })
+
+      for (const tool of Mcp.collectTools(commands, [])) {
+        const mergedShape: Record<string, any> = {
+          ...tool.command.args?.shape,
+          ...tool.command.options?.shape,
+        }
+        const hasInput = Object.keys(mergedShape).length > 0
+
+        server.registerTool(
+          tool.name,
+          {
+            ...(tool.description ? { description: tool.description } : undefined),
+            ...(hasInput ? { inputSchema: mergedShape } : undefined),
+          },
+          async (...callArgs: any[]) => {
+            const params = hasInput ? (callArgs[0] as Record<string, unknown>) : {}
+            return Mcp.callTool(tool, params)
+          },
+        )
+      }
+
+      transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: () => crypto.randomUUID(),
+        enableJsonResponse: true,
+      })
+      await server.connect(transport)
+    }
+    return transport.handleRequest(req)
+  }
+}
+
+/** @internal Handles an HTTP request by resolving a command and returning a JSON Response. */
+async function fetchImpl(
+  name: string,
+  commands: Map<string, CommandEntry>,
+  req: Request,
+  options: fetchImpl.Options = {},
+): Promise<Response> {
+  const start = performance.now()
+
+  const url = new URL(req.url)
+  const segments = url.pathname.split('/').filter(Boolean)
+
+  // MCP over HTTP: route /mcp to the MCP transport
+  if (segments[0] === 'mcp' && segments.length === 1 && options.mcpHandler)
+    return options.mcpHandler(req, commands)
+
+  // Parse options from search params (GET) or body (non-GET)
+  let inputOptions: Record<string, unknown> = {}
+  if (req.method === 'GET')
+    for (const [key, value] of url.searchParams) inputOptions[key] = value
+  else {
+    try {
+      const contentType = req.headers.get('content-type') ?? ''
+      if (contentType.includes('application/json')) inputOptions = (await req.json()) as Record<string, unknown>
+    } catch {}
+  }
+
+  function jsonResponse(body: unknown, status: number) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  // Resolve command from path segments
+  if (segments.length === 0) {
+    // Root path
+    if (options.rootCommand)
+      return executeCommand(name, options.rootCommand, [], inputOptions, start, options)
+    return jsonResponse(
+      { ok: false, error: { code: 'COMMAND_NOT_FOUND', message: 'No root command defined.' }, meta: { command: '/', duration: `${Math.round(performance.now() - start)}ms` } },
+      404,
+    )
+  }
+
+  const resolved = resolveCommand(commands, segments)
+
+  if ('error' in resolved)
+    return jsonResponse(
+      { ok: false, error: { code: 'COMMAND_NOT_FOUND', message: `'${resolved.error}' is not a command for '${resolved.path ? `${name} ${resolved.path}` : name}'.` }, meta: { command: resolved.error, duration: `${Math.round(performance.now() - start)}ms` } },
+      404,
+    )
+
+  if ('help' in resolved)
+    return jsonResponse(
+      { ok: false, error: { code: 'COMMAND_NOT_FOUND', message: `'${resolved.path}' is a command group. Specify a subcommand.` }, meta: { command: resolved.path, duration: `${Math.round(performance.now() - start)}ms` } },
+      404,
+    )
+
+  if ('fetchGateway' in resolved)
+    return resolved.fetchGateway.fetch(req)
+
+  const { command, path, rest } = resolved
+  return executeCommand(path, command, rest, inputOptions, start, options)
+}
+
+/** @internal Executes a resolved command for the fetch handler and returns a JSON Response. */
+async function executeCommand(
+  path: string,
+  command: CommandDefinition<any, any, any>,
+  rest: string[],
+  inputOptions: Record<string, unknown>,
+  start: number,
+  options: fetchImpl.Options,
+): Promise<Response> {
+  function jsonResponse(body: unknown, status: number) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  const sentinel_ = Symbol.for('incur.sentinel')
+  const varsMap: Record<string, unknown> = options.vars ? options.vars.parse({}) : {}
+  let response: Response | undefined
+
+  const runCommand = async () => {
+    const { args } = Parser.parse(rest, { args: command.args })
+    const parsedOptions = command.options ? command.options.parse(inputOptions) : {}
+
+    const okFn = (data: unknown): never => ({ [sentinel_]: 'ok', data }) as never
+    const errorFn = (opts: { code: string; message: string; exitCode?: number | undefined }): never =>
+      ({ [sentinel_]: 'error', ...opts }) as never
+
+    const result = command.run({
+      agent: true,
+      args,
+      env: {},
+      name: path,
+      options: parsedOptions,
+      ok: okFn,
+      error: errorFn,
+      var: varsMap,
+      version: undefined,
+    })
+
+    // Streaming path — async generator → NDJSON response
+    if (isAsyncGenerator(result)) {
+      const stream = new ReadableStream({
+        async start(controller) {
+          const encoder = new TextEncoder()
+          try {
+            let returnValue: unknown
+            while (true) {
+              const { value, done } = await result.next()
+              if (done) {
+                returnValue = value
+                break
+              }
+              if (isSentinel(value) && (value as any)[sentinel] === 'error') {
+                const tagged = value as any
+                controller.enqueue(encoder.encode(JSON.stringify({ type: 'error', ok: false, error: { code: tagged.code, message: tagged.message } }) + '\n'))
+                controller.close()
+                return
+              }
+              controller.enqueue(encoder.encode(JSON.stringify({ type: 'chunk', data: value }) + '\n'))
+            }
+            const meta: Record<string, unknown> = { command: path }
+            if (isSentinel(returnValue) && (returnValue as any)[sentinel] === 'error') {
+              const tagged = returnValue as any
+              controller.enqueue(encoder.encode(JSON.stringify({ type: 'error', ok: false, error: { code: tagged.code, message: tagged.message } }) + '\n'))
+            } else {
+              controller.enqueue(encoder.encode(JSON.stringify({ type: 'done', ok: true, meta }) + '\n'))
+            }
+          } catch (error) {
+            controller.enqueue(encoder.encode(JSON.stringify({ type: 'error', ok: false, error: { code: 'UNKNOWN', message: error instanceof Error ? error.message : String(error) } }) + '\n'))
+          }
+          controller.close()
+        },
+      })
+      response = new Response(stream, { status: 200, headers: { 'content-type': 'application/x-ndjson' } })
+      return
+    }
+
+    const awaited = await result
+    const duration = `${Math.round(performance.now() - start)}ms`
+
+    if (typeof awaited === 'object' && awaited !== null && sentinel_ in awaited) {
+      const tagged = awaited as any
+      if (tagged[sentinel_] === 'error')
+        response = jsonResponse(
+          { ok: false, error: { code: tagged.code, message: tagged.message }, meta: { command: path, duration } },
+          500,
+        )
+      else
+        response = jsonResponse(
+          { ok: true, data: tagged.data, meta: { command: path, duration } },
+          200,
+        )
+      return
+    }
+
+    response = jsonResponse(
+      { ok: true, data: awaited, meta: { command: path, duration } },
+      200,
+    )
+  }
+
+  try {
+    const allMiddleware = options.middlewares ?? []
+    if (allMiddleware.length > 0) {
+      const errorFn = (opts: { code: string; message: string; exitCode?: number | undefined }): never => {
+        const duration = `${Math.round(performance.now() - start)}ms`
+        response = jsonResponse(
+          { ok: false, error: { code: opts.code, message: opts.message }, meta: { command: path, duration } },
+          500,
+        )
+        return undefined as never
+      }
+      const mwCtx: MiddlewareContext = {
+        agent: true,
+        command: path,
+        env: {},
+        error: errorFn,
+        name: path,
+        set(key: string, value: unknown) { varsMap[key] = value },
+        var: varsMap,
+        version: undefined,
+      }
+      const composed = allMiddleware.reduceRight(
+        (next: () => Promise<void>, mw) => async () => { await mw(mwCtx, next) },
+        runCommand,
+      )
+      await composed()
+    } else {
+      await runCommand()
+    }
+  } catch (error) {
+    const duration = `${Math.round(performance.now() - start)}ms`
+    if (error instanceof ValidationError)
+      return jsonResponse(
+        { ok: false, error: { code: 'VALIDATION_ERROR', message: error.message }, meta: { command: path, duration } },
+        400,
+      )
+    return jsonResponse(
+      { ok: false, error: { code: error instanceof IncurError ? error.code : 'UNKNOWN', message: error instanceof Error ? error.message : String(error) }, meta: { command: path, duration } },
+      500,
+    )
+  }
+
+  return response!
 }
 
 /** @internal Formats a validation error for TTY with usage hint. */

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -52,7 +52,7 @@ export declare namespace serve {
 }
 
 /** @internal Executes a tool call and returns a CallToolResult. */
-async function callTool(
+export async function callTool(
   tool: ToolEntry,
   params: Record<string, unknown>,
   extra?: {
@@ -135,7 +135,7 @@ function isAsyncGenerator(value: unknown): value is AsyncGenerator<unknown, unkn
 }
 
 /** @internal A resolved tool entry from the command tree. */
-type ToolEntry = {
+export type ToolEntry = {
   name: string
   description?: string | undefined
   inputSchema: { type: 'object'; properties: Record<string, unknown>; required?: string[] }
@@ -143,7 +143,7 @@ type ToolEntry = {
 }
 
 /** @internal Recursively collects leaf commands as tool entries. */
-function collectTools(commands: Map<string, any>, prefix: string[]): ToolEntry[] {
+export function collectTools(commands: Map<string, any>, prefix: string[]): ToolEntry[] {
   const result: ToolEntry[] = []
   for (const [name, entry] of commands) {
     const path = [...prefix, name]

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1952,6 +1952,517 @@ describe('fetch gateway', () => {
   })
 })
 
+async function fetchJson(cli: Cli.Cli<any, any, any>, req: Request) {
+  const res = await cli.fetch(req)
+  const body = await res.json()
+  if (body.meta?.duration) body.meta.duration = '<stripped>'
+  return { status: res.status, body }
+}
+
+describe('fetch api', () => {
+  test('GET /ping → 200 with data', async () => {
+    const cli = createApp()
+    expect(await fetchJson(cli, new Request('http://localhost/ping'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "pong": true,
+          },
+          "meta": {
+            "command": "ping",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('GET /unknown → 404', async () => {
+    const cli = createApp()
+    expect(await fetchJson(cli, new Request('http://localhost/unknown'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "COMMAND_NOT_FOUND",
+            "message": "'unknown' is not a command for 'app'.",
+          },
+          "meta": {
+            "command": "unknown",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 404,
+      }
+    `)
+  })
+
+  test('GET / without root command → 404', async () => {
+    const cli = createApp()
+    expect(await fetchJson(cli, new Request('http://localhost/'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "COMMAND_NOT_FOUND",
+            "message": "No root command defined.",
+          },
+          "meta": {
+            "command": "/",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 404,
+      }
+    `)
+  })
+
+  test('GET with query params → options', async () => {
+    const cli = createApp()
+    expect(await fetchJson(cli, new Request('http://localhost/echo/hi?prefix=yo'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "result": [
+              "yo hi",
+            ],
+          },
+          "meta": {
+            "command": "echo",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('POST with JSON body → options', async () => {
+    const cli = createApp()
+    const req = new Request('http://localhost/project/create/MyProject', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ description: 'A test project' }),
+    })
+    expect(await fetchJson(cli, req)).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "id": "p-new",
+            "url": "https://example.com/projects/p-new",
+          },
+          "meta": {
+            "command": "project create",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('trailing path segments → positional args', async () => {
+    const cli = createApp()
+    expect(await fetchJson(cli, new Request('http://localhost/project/get/p1'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "description": "Main project",
+            "id": "p1",
+            "members": [
+              {
+                "role": "admin",
+                "userId": "u1",
+              },
+            ],
+            "name": "Alpha",
+          },
+          "meta": {
+            "command": "project get",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('nested command (3 levels deep)', async () => {
+    const cli = createApp()
+    expect(await fetchJson(cli, new Request('http://localhost/project/deploy/status/d-456'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "deployId": "d-456",
+            "progress": 75,
+            "status": "running",
+          },
+          "meta": {
+            "command": "project deploy status",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('thrown error → 500', async () => {
+    const cli = createApp()
+    expect(await fetchJson(cli, new Request('http://localhost/explode'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "UNKNOWN",
+            "message": "kaboom",
+          },
+          "meta": {
+            "command": "explode",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 500,
+      }
+    `)
+  })
+
+  test('IncurError → 500 with code', async () => {
+    const cli = createApp()
+    expect(await fetchJson(cli, new Request('http://localhost/explode-clac'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "QUOTA_EXCEEDED",
+            "message": "Rate limit exceeded",
+          },
+          "meta": {
+            "command": "explode-clac",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 500,
+      }
+    `)
+  })
+
+  test('validation error → 400', async () => {
+    const cli = createApp()
+    const { status, body } = await fetchJson(cli, new Request('http://localhost/validate-fail'))
+    expect(status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  test('async generator → NDJSON streaming', async () => {
+    const cli = createApp()
+    const res = await cli.fetch(new Request('http://localhost/stream'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('application/x-ndjson')
+    const lines = (await res.text()).trim().split('\n').map((l) => JSON.parse(l))
+    expect(lines).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {
+            "content": "hello",
+          },
+          "type": "chunk",
+        },
+        {
+          "data": {
+            "content": "world",
+          },
+          "type": "chunk",
+        },
+        {
+          "meta": {
+            "command": "stream",
+          },
+          "ok": true,
+          "type": "done",
+        },
+      ]
+    `)
+  })
+
+  test('fetch gateway → forwards request', async () => {
+    const handler = (req: Request) => {
+      const url = new URL(req.url)
+      return new Response(JSON.stringify({ path: url.pathname }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    const cli = Cli.create('test')
+    cli.command('api', { fetch: handler })
+    const res = await cli.fetch(new Request('http://localhost/api/users'))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchInlineSnapshot(`
+      {
+        "path": "/api/users",
+      }
+    `)
+  })
+
+  test('middleware sets var → command sees it', async () => {
+    const { cli } = createMiddlewareApp()
+    expect(await fetchJson(cli, new Request('http://localhost/whoami'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "requestId": "req-default",
+            "user": "alice",
+          },
+          "meta": {
+            "command": "whoami",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('middleware error → error response', async () => {
+    const cli = Cli.create('test')
+    cli.use((c) => { c.error({ code: 'FORBIDDEN', message: 'nope' }) })
+    cli.command('secret', { run: () => ({ secret: true }) })
+    expect(await fetchJson(cli, new Request('http://localhost/secret'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": {
+            "code": "FORBIDDEN",
+            "message": "nope",
+          },
+          "meta": {
+            "command": "secret",
+            "duration": "<stripped>",
+          },
+          "ok": false,
+        },
+        "status": 500,
+      }
+    `)
+  })
+
+  describe('mcp over http', () => {
+    function mcpRequest(cli: Cli.Cli<any, any, any>, body: unknown, sessionId?: string) {
+      const headers: Record<string, string> = {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      }
+      if (sessionId) headers['mcp-session-id'] = sessionId
+      return cli.fetch(
+        new Request('http://localhost/mcp', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+        }),
+      )
+    }
+
+    async function initSession(cli: Cli.Cli<any, any, any>) {
+      const res = await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      })
+      const sessionId = res.headers.get('mcp-session-id')!
+      await mcpRequest(cli, { jsonrpc: '2.0', method: 'notifications/initialized' }, sessionId)
+      return sessionId
+    }
+
+    test('initialize → returns server info and capabilities', async () => {
+      const cli = createApp()
+      const res = await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect({
+        serverInfo: body.result.serverInfo,
+        hasTools: 'tools' in (body.result.capabilities ?? {}),
+      }).toMatchInlineSnapshot(`
+        {
+          "hasTools": true,
+          "serverInfo": {
+            "name": "app",
+            "version": "3.5.0",
+          },
+        }
+      `)
+    })
+
+    test('tools/list → lists all registered tools', async () => {
+      const cli = createApp()
+      const sessionId = await initSession(cli)
+      const res = await mcpRequest(
+        cli,
+        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+        sessionId,
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      const names = body.result.tools.map((t: any) => t.name).sort()
+      expect(names).toMatchInlineSnapshot(`
+        [
+          "api",
+          "auth_login",
+          "auth_logout",
+          "auth_status",
+          "config",
+          "echo",
+          "explode",
+          "explode-clac",
+          "noop",
+          "ping",
+          "project_create",
+          "project_delete",
+          "project_deploy_create",
+          "project_deploy_rollback",
+          "project_deploy_status",
+          "project_get",
+          "project_list",
+          "slow",
+          "stream",
+          "stream-error",
+          "stream-ok",
+          "stream-text",
+          "stream-throw",
+          "validate-fail",
+        ]
+      `)
+    })
+
+    test('tools/call → executes command and returns result', async () => {
+      const cli = createApp()
+      const sessionId = await initSession(cli)
+      const res = await mcpRequest(
+        cli,
+        {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: { name: 'echo', arguments: { message: 'hello' } },
+        },
+        sessionId,
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect({
+        isError: body.result.isError,
+        content: JSON.parse(body.result.content[0].text),
+      }).toMatchInlineSnapshot(`
+        {
+          "content": {
+            "result": [
+              "hello",
+            ],
+          },
+          "isError": undefined,
+        }
+      `)
+    })
+
+    test('tools/call with nested command', async () => {
+      const cli = createApp()
+      const sessionId = await initSession(cli)
+      const res = await mcpRequest(
+        cli,
+        {
+          jsonrpc: '2.0',
+          id: 4,
+          method: 'tools/call',
+          params: { name: 'project_get', arguments: { id: 'p1' } },
+        },
+        sessionId,
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(JSON.parse(body.result.content[0].text)).toMatchInlineSnapshot(`
+        {
+          "description": "Main project",
+          "id": "p1",
+          "members": [
+            {
+              "role": "admin",
+              "userId": "u1",
+            },
+          ],
+          "name": "Alpha",
+        }
+      `)
+    })
+
+    test('tools/call with error → isError true', async () => {
+      const cli = createApp()
+      const sessionId = await initSession(cli)
+      const res = await mcpRequest(
+        cli,
+        {
+          jsonrpc: '2.0',
+          id: 5,
+          method: 'tools/call',
+          params: { name: 'explode', arguments: {} },
+        },
+        sessionId,
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect({
+        isError: body.result.isError,
+        text: body.result.content[0].text,
+      }).toMatchInlineSnapshot(`
+        {
+          "isError": true,
+          "text": "kaboom",
+        }
+      `)
+    })
+
+    test('non-/mcp paths still work alongside MCP', async () => {
+      const cli = createApp()
+      // Initialize MCP first
+      await initSession(cli)
+      // Regular fetch still works
+      expect(await fetchJson(cli, new Request('http://localhost/ping'))).toMatchInlineSnapshot(`
+        {
+          "body": {
+            "data": {
+              "pong": true,
+            },
+            "meta": {
+              "command": "ping",
+              "duration": "<stripped>",
+            },
+            "ok": true,
+          },
+          "status": 200,
+        }
+      `)
+    })
+  })
+})
+
 async function serve(
   cli: { serve: Cli.Cli['serve'] },
   argv: string[],


### PR DESCRIPTION
Added `cli.fetch` to expose CLI as a standard Fetch API handler.

- **Core routing**: path segments → commands, query params → options (GET), JSON body → options (POST), trailing segments → positional args
- **Streaming**: async generator commands return NDJSON (`application/x-ndjson`)
- **Fetch gateways**: `.command('api', { fetch })` forwards requests to nested handlers
- **Middleware**: runs the same as `serve()` — `c.set`, `c.var`, `c.error` short-circuiting
- **MCP over HTTP**: `/mcp` endpoint with lazy initialization, reuses tool collection from `Mcp.ts`

```ts
Bun.serve(cli) // Bun
Deno.serve(cli.fetch) // Deno
export default cli // Cloudflare Workers
app.all('*', c => cli.fetch(c.request)) // Elysia
app.use(c => cli.fetch(c.req.raw)) // Hono
export const GET = cli.fetch // Next.js
export const POST = cli.fetch
```