### PR TITLE
feat: add `c.human` output channel for run and middleware contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,16 +687,53 @@ $ my-cli deploy --zone us-east-1
 # Warning: --zone is deprecated
 ```
 
-### Agent detection
+### Human output
 
-The `run` context includes an `agent` boolean — `true` when stdout is not a TTY (piped or consumed by an agent), `false` when running in a terminal. Use it to tailor behavior:
+The `run` context includes `human`, a dedicated human-only output channel. It writes to stderr when a terminal is attached, never mixes with structured stdout output, and safely no-ops when unavailable:
 
 ```ts
 cli.command('deploy', {
   args: z.object({ env: z.enum(['staging', 'production']) }),
   run(c) {
-    if (!c.agent) console.log(`Deploying to ${c.args.env}...`)
+    c.human.writeln(`Deploying to ${c.args.env}...`)
     return { url: `https://${c.args.env}.example.com` }
+  },
+})
+```
+
+Use `c.human.stream` when you want to hand a live TTY stream to a third-party spinner or progress library.
+
+```ts
+import ora from 'ora'
+
+cli.command('deploy', {
+  async run(c) {
+    const spinner = c.human.stream
+      ? ora({ stream: c.human.stream, text: 'Deploying...' }).start()
+      : undefined
+
+    try {
+      await deployApp()
+      spinner?.succeed('Done')
+      return { ok: true }
+    } catch (err) {
+      spinner?.fail('Failed')
+      throw err
+    }
+  },
+})
+```
+
+### Agent detection
+
+The `run` context also includes an `agent` boolean — `true` when stdout is not a TTY (piped or consumed by an agent), `false` when running in a terminal. `c.agent` and `c.human.enabled` are independent, so a command can still render human progress on stderr while writing machine-readable stdout:
+
+```ts
+cli.command('deploy', {
+  args: z.object({ env: z.enum(['staging', 'production']) }),
+  run(c) {
+    c.human.writeln(`Deploying to ${c.args.env}...`)
+    return { agent: c.agent, human: c.human.enabled }
   },
 })
 ```
@@ -807,18 +844,18 @@ Every incur CLI includes these flags automatically:
 
 | Flag                     | Description                                            |
 | ------------------------ | ------------------------------------------------------ |
-| `--help`, `-h`           | Show help for the CLI or a specific command             |
+| `--help`, `-h`           | Show help for the CLI or a specific command            |
 | `--version`              | Print CLI version                                      |
-| `--llms`                 | Output agent-readable command manifest                  |
-| `--mcp`                  | Start as an MCP stdio server                            |
-| `--json`                 | Shorthand for `--format json`                           |
-| `--format <fmt>`         | Output format: `toon`, `json`, `yaml`, `md`             |
+| `--llms`                 | Output agent-readable command manifest                 |
+| `--mcp`                  | Start as an MCP stdio server                           |
+| `--json`                 | Shorthand for `--format json`                          |
+| `--format <fmt>`         | Output format: `toon`, `json`, `yaml`, `md`            |
 | `--filter-output <keys>` | Filter output by key paths (e.g. `foo,bar.baz,a[0,3]`) |
-| `--schema`               | Show JSON Schema for a command's args, options, output  |
-| `--token-count`          | Print token count of output instead of output           |
-| `--token-limit <n>`      | Limit output to n tokens (for pagination)               |
-| `--token-offset <n>`     | Skip first n tokens of output (for pagination)          |
-| `--verbose`              | Include full envelope (`ok`, `data`, `meta`)            |
+| `--schema`               | Show JSON Schema for a command's args, options, output |
+| `--token-count`          | Print token count of output instead of output          |
+| `--token-limit <n>`      | Limit output to n tokens (for pagination)              |
+| `--token-offset <n>`     | Skip first n tokens of output (for pagination)         |
+| `--verbose`              | Include full envelope (`ok`, `data`, `meta`)           |
 
 ### Filtering output
 

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -189,6 +189,10 @@ test('middleware() without generic gives empty context', () => {
     expectTypeOf(c.env).toEqualTypeOf<{}>()
     expectTypeOf(c.format).toEqualTypeOf<'toon' | 'json' | 'yaml' | 'md' | 'jsonl'>()
     expectTypeOf(c.formatExplicit).toEqualTypeOf<boolean>()
+    expectTypeOf(c.human.enabled).toEqualTypeOf<boolean>()
+    expectTypeOf(c.human.stream).toEqualTypeOf<NodeJS.WriteStream | undefined>()
+    expectTypeOf(c.human.write).returns.toEqualTypeOf<void>()
+    expectTypeOf(c.human.writeln).returns.toEqualTypeOf<void>()
   })
 })
 
@@ -285,6 +289,12 @@ test('run() context exposes format metadata', () => {
     run(c) {
       expectTypeOf(c.format).toEqualTypeOf<'toon' | 'json' | 'yaml' | 'md' | 'jsonl'>()
       expectTypeOf(c.formatExplicit).toEqualTypeOf<boolean>()
+      expectTypeOf(c.human.enabled).toEqualTypeOf<boolean>()
+      expectTypeOf(c.human.stream).toEqualTypeOf<NodeJS.WriteStream | undefined>()
+      expectTypeOf(c.human.write).parameters.toEqualTypeOf<[text: string]>()
+      expectTypeOf(c.human.write).returns.toEqualTypeOf<void>()
+      expectTypeOf(c.human.writeln).parameters.toEqualTypeOf<[text: string]>()
+      expectTypeOf(c.human.writeln).returns.toEqualTypeOf<void>()
       return { pong: true }
     },
   })

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -1,11 +1,14 @@
 import { Cli, Errors, z } from 'incur'
 
 const originalIsTTY = process.stdout.isTTY
+const originalStderrIsTTY = process.stderr.isTTY
 beforeAll(() => {
   ;(process.stdout as any).isTTY = false
+  ;(process.stderr as any).isTTY = false
 })
 afterAll(() => {
   ;(process.stdout as any).isTTY = originalIsTTY
+  ;(process.stderr as any).isTTY = originalStderrIsTTY
 })
 
 let __mockSkillsHash: string | undefined
@@ -21,18 +24,23 @@ async function serve(
   options: Cli.serve.Options = {},
 ) {
   let output = ''
+  let stderr = ''
   let exitCode: number | undefined
+  const stdout = options.stdout ?? ((s: string) => { output += s })
+  const stderrWriter = options.stderr ?? ((s: string) => { process.stderr.write(s) })
+  const exit = options.exit ?? ((code: number) => { exitCode = code })
   await cli.serve(argv, {
-    stdout(s) {
-      output += s
-    },
-    exit(code) {
-      exitCode = code
-    },
     ...options,
+    stderr(s) {
+      stderr += s
+      stderrWriter(s)
+    },
+    stdout,
+    exit,
   })
   return {
     output: output.replace(/duration: \d+ms/, 'duration: <stripped>'),
+    stderr,
     exitCode,
   }
 }
@@ -2683,6 +2691,119 @@ test('streaming: c.error({ exitCode }) in yield uses custom exit code', async ()
   expect(output).toContain('STREAM_ERR')
 })
 
+describe('human output', () => {
+  beforeEach(() => {
+    __mockSkillsHash = undefined
+  })
+
+  afterEach(() => {
+    __mockSkillsHash = undefined
+    ;(process.stdout as any).isTTY = false
+    ;(process.stderr as any).isTTY = false
+  })
+
+  test('run() writes human output to stderr only', async () => {
+    ;(process.stderr as any).isTTY = true
+    const cli = Cli.create('test')
+    cli.command('deploy', {
+      run(c) {
+        c.human.writeln('Deploying...')
+        return { ok: true }
+      },
+    })
+
+    const { output, stderr } = await serve(cli, ['deploy'], { stderr() {} })
+    expect(output).toContain('ok: true')
+    expect(stderr).toBe('Deploying...\n')
+  })
+
+  test('human output stays active when stdout is piped', async () => {
+    ;(process.stdout as any).isTTY = false
+    ;(process.stderr as any).isTTY = true
+    const cli = Cli.create('test')
+    cli.command('status', {
+      run(c) {
+        c.human.writeln('Checking status...')
+        return { agent: c.agent, human: c.human.enabled }
+      },
+    })
+
+    const { output, stderr } = await serve(cli, ['status', '--format', 'json'], { stderr() {} })
+    expect(JSON.parse(output)).toEqual({ agent: true, human: true })
+    expect(stderr).toBe('Checking status...\n')
+  })
+
+  test('human output noops when stderr is not a tty', async () => {
+    ;(process.stderr as any).isTTY = false
+    const cli = Cli.create('test')
+    cli.command('status', {
+      run(c) {
+        c.human.writeln('hidden')
+        return { human: c.human.enabled }
+      },
+    })
+
+    const { output, stderr } = await serve(cli, ['status'], { stderr() {} })
+    expect(output).toContain('human: false')
+    expect(stderr).toBe('')
+  })
+
+  test('middleware receives the same human output helpers', async () => {
+    ;(process.stderr as any).isTTY = true
+    const cli = Cli.create('test')
+      .use(async (c, next) => {
+        c.human.writeln(`Running ${c.command}...`)
+        await next()
+      })
+      .command('status', {
+        run() {
+          return { ok: true }
+        },
+      })
+
+    const { output, stderr } = await serve(cli, ['status'], { stderr() {} })
+    expect(output).toContain('ok: true')
+    expect(stderr).toBe('Running status...\n')
+  })
+
+  test('streaming human output does not break jsonl output', async () => {
+    ;(process.stderr as any).isTTY = true
+    const cli = Cli.create('test')
+    cli.command('stream', {
+      async *run(c) {
+        c.human.writeln('Starting stream...')
+        yield { step: 1 }
+        c.human.writeln('Between chunks...')
+        yield { step: 2 }
+      },
+    })
+
+    const { output, stderr } = await serve(cli, ['stream', '--format', 'jsonl'], { stderr() {} })
+    const lines = output.trim().split('\n').map((line) => JSON.parse(line))
+    expect(lines[0]).toEqual({ type: 'chunk', data: { step: 1 } })
+    expect(lines[1]).toEqual({ type: 'chunk', data: { step: 2 } })
+    expect(lines[2].type).toBe('done')
+    expect(stderr).toBe('Starting stream...\nBetween chunks...\n')
+  })
+
+  test('agent-only still allows human output', async () => {
+    ;(process.stdout as any).isTTY = true
+    ;(process.stderr as any).isTTY = true
+    const cli = Cli.create('test')
+    cli.command('deploy', {
+      outputPolicy: 'agent-only',
+      run(c) {
+        c.human.writeln('Deploying...')
+        return { ok: true }
+      },
+    })
+
+    const { output, stderr } = await serve(cli, ['deploy'], { stderr() {} })
+    expect(output).toBe('')
+    expect(stderr).toBe('Deploying...\n')
+  })
+})
+
 test('deprecated short flag emits warning', async () => {
   const cli = Cli.create('app').command('deploy', {
     options: z.object({
@@ -3008,6 +3129,32 @@ describe('fetch', () => {
       {
         "body": {
           "data": {
+            "ok": true,
+          },
+          "meta": {
+            "command": "health",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('human writes are ignored in fetch()', async () => {
+    const cli = Cli.create('test')
+    cli.command('health', {
+      run(c) {
+        c.human.writeln('hidden')
+        return { ok: true, human: c.human.enabled }
+      },
+    })
+    expect(await fetchJson(cli, new Request('http://localhost/health'))).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "human": false,
             "ok": true,
           },
           "meta": {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -10,6 +10,7 @@ import * as Openapi from './Openapi.js'
 import * as Formatter from './Formatter.js'
 import * as Help from './Help.js'
 import { detectRunner } from './internal/pm.js'
+import { createHuman, createRunContext, type RunContext } from './internal/run.js'
 import type { OneOf } from './internal/types.js'
 import * as Mcp from './Mcp.js'
 import type { Context as MiddlewareContext, Handler as MiddlewareHandler } from './middleware.js'
@@ -251,8 +252,10 @@ export function create(
       return fetchImpl(name, commands, req, {
         mcpHandler,
         middlewares,
+        name,
         rootCommand: rootDef,
         vars: def.vars,
+        version: def.version,
       })
     },
 
@@ -334,33 +337,7 @@ export declare namespace create {
     vars?: vars | undefined
     /** The root command handler. When provided, creates a leaf CLI with no subcommands. */
     run?:
-      | ((context: {
-          /** Whether the consumer is an agent (stdout is not a TTY). */
-          agent: boolean
-          /** Positional arguments. */
-          args: InferOutput<args>
-          /** Parsed environment variables. */
-          env: InferOutput<env>
-          /** Return an error result with optional CTAs. */
-          error: (options: {
-            code: string
-            cta?: CtaBlock | undefined
-            exitCode?: number | undefined
-            message: string
-            retryable?: boolean | undefined
-          }) => never
-          /** The resolved output format (e.g. `'toon'`, `'json'`, `'jsonl'`). */
-          format: Formatter.Format
-          /** Whether the user explicitly passed `--format` or `--json`. */
-          formatExplicit: boolean
-          /** The CLI name. */
-          name: string
-          /** Return a success result with optional metadata (e.g. CTAs). */
-          ok: (data: InferReturn<output>, meta?: { cta?: CtaBlock | undefined }) => never
-          options: InferOutput<options>
-          /** Variables set by middleware. */
-          var: InferVars<vars>
-        }) =>
+      | ((context: RunContext<args, env, options, output, vars, CtaBlock>) =>
           | InferReturn<output>
           | Promise<InferReturn<output>>
           | AsyncGenerator<InferReturn<output>, unknown, unknown>)
@@ -399,6 +376,8 @@ export declare namespace serve {
     env?: Record<string, string | undefined> | undefined
     /** Override exit handler. Defaults to `process.exit`. */
     exit?: ((code: number) => void) | undefined
+    /** Override stderr writer for human-only output. Defaults to `process.stderr.write`. */
+    stderr?: ((s: string) => void) | undefined
     /** Override stdout writer. Defaults to `process.stdout.write`. */
     stdout?: ((s: string) => void) | undefined
   }
@@ -413,6 +392,7 @@ async function serveImpl(
   options: serveImpl.Options = {},
 ) {
   const stdout = options.stdout ?? ((s: string) => process.stdout.write(s))
+  const stderr = options.stderr ?? ((s: string) => process.stderr.write(s))
   const exit = options.exit ?? ((code: number) => process.exit(code))
 
   const {
@@ -458,6 +438,13 @@ async function serveImpl(
 
   // Human mode: stdout is a TTY.
   const human = process.stdout.isTTY === true
+  const humanOutput = createHuman({
+    enabled: process.stderr.isTTY === true,
+    ...(process.stderr.isTTY === true && options.stderr === undefined
+      ? { stream: process.stderr }
+      : undefined),
+    write: stderr,
+  })
 
   function writeln(s: string) {
     stdout(s.endsWith('\n') ? s : `${s}\n`)
@@ -476,7 +463,7 @@ async function serveImpl(
         if (Skill.hash(entries) !== stored) {
           const runner = detectRunner()
           const spec = SyncMcp.detectPackageSpecifier(name)
-          process.stderr.write(
+          stderr(
             `⚠ Skills are out of date. Run '${runner} ${spec} skills add' to update.\n\n`,
           )
         }
@@ -1081,6 +1068,7 @@ async function serveImpl(
           error: errorFn,
           format,
           formatExplicit,
+          human: humanOutput,
           name,
           set(key: string, value: unknown) { varsMap[key] = value },
           var: varsMap,
@@ -1146,6 +1134,7 @@ async function serveImpl(
         rest,
         command.options,
         command.alias as Record<string, string> | undefined,
+        stderr,
       )
 
     const env = command.env ? Parser.parseEnv(command.env, envSource) : {}
@@ -1163,19 +1152,22 @@ async function serveImpl(
       return { [sentinel]: 'error', ...opts } as never
     }
 
-    const result = command.run({
-      agent: !human,
-      args,
-      env,
-      error: errorFn,
-      format,
-      formatExplicit,
-      name,
-      ok: okFn,
-      options: parsedOptions,
-      var: varsMap,
-      version: options.version,
-    })
+    const result = command.run(
+      createRunContext({
+        agent: !human,
+        args,
+        env,
+        error: errorFn,
+        format,
+        formatExplicit,
+        human: humanOutput,
+        name,
+        ok: okFn,
+        options: parsedOptions,
+        var: varsMap,
+        version: options.version,
+      }),
+    )
 
     // Streaming path — async generator
     if (isAsyncGenerator(result)) {
@@ -1259,6 +1251,7 @@ async function serveImpl(
         error: errorFn,
         format,
         formatExplicit,
+        human: humanOutput,
         name,
         set(key: string, value: unknown) {
           varsMap[key] = value
@@ -1331,8 +1324,10 @@ declare namespace fetchImpl {
   type Options = {
     mcpHandler?: ((req: Request, commands: Map<string, CommandEntry>) => Promise<Response>) | undefined
     middlewares?: MiddlewareHandler[] | undefined
+    name: string
     rootCommand?: CommandDefinition<any, any, any> | undefined
     vars?: z.ZodObject<any> | undefined
+    version?: string | undefined
   }
 }
 
@@ -1384,7 +1379,7 @@ async function fetchImpl(
   name: string,
   commands: Map<string, CommandEntry>,
   req: Request,
-  options: fetchImpl.Options = {},
+  options: fetchImpl.Options = { name },
 ): Promise<Response> {
   const start = performance.now()
 
@@ -1512,23 +1507,33 @@ async function executeCommand(
     const { args } = Parser.parse(rest, { args: command.args })
     const parsedOptions = command.options ? command.options.parse(inputOptions) : {}
 
-    const okFn = (data: unknown): never => ({ [sentinel_]: 'ok', data }) as never
-    const errorFn = (opts: { code: string; message: string; exitCode?: number | undefined }): never =>
+    const okFn = (data: unknown, _meta: { cta?: unknown | undefined } = {}): never =>
+      ({ [sentinel_]: 'ok', data }) as never
+    const errorFn = (opts: {
+      code: string
+      cta?: unknown | undefined
+      exitCode?: number | undefined
+      message: string
+      retryable?: boolean | undefined
+    }): never =>
       ({ [sentinel_]: 'error', ...opts }) as never
 
-    const result = command.run({
-      agent: true,
-      args,
-      env: {},
-      error: errorFn,
-      format: 'json',
-      formatExplicit: true,
-      name: path,
-      ok: okFn,
-      options: parsedOptions,
-      var: varsMap,
-      version: undefined,
-    })
+    const result = command.run(
+      createRunContext({
+        agent: true,
+        args,
+        env: {},
+        error: errorFn,
+        format: 'json',
+        formatExplicit: true,
+        human: createHuman(),
+        name: options.name,
+        ok: okFn,
+        options: parsedOptions,
+        var: varsMap,
+        version: options.version,
+      }),
+    )
 
     // Streaming path — async generator → NDJSON response
     if (isAsyncGenerator(result)) {
@@ -1610,10 +1615,11 @@ async function executeCommand(
         error: errorFn,
         format: 'json',
         formatExplicit: true,
-        name: path,
+        human: createHuman(),
+        name: options.name,
         set(key: string, value: unknown) { varsMap[key] = value },
         var: varsMap,
-        version: undefined,
+        version: options.version,
       }
       const composed = allMiddleware.reduceRight(
         (next: () => Promise<void>, mw) => async () => { await mw(mwCtx, next) },
@@ -2489,35 +2495,7 @@ type CommandDefinition<
   /** Alternative usage patterns shown in help output. */
   usage?: Usage<args, options>[] | undefined
   /** The command handler. Return a value for single-return, or use `async *run` to stream chunks. */
-  run(context: {
-    /** Whether the consumer is an agent (stdout is not a TTY). */
-    agent: boolean
-    /** Positional arguments. */
-    args: InferOutput<args>
-    /** Parsed environment variables. */
-    env: InferOutput<env>
-    /** Return an error result with optional CTAs. */
-    error: (options: {
-      code: string
-      cta?: CtaBlock | undefined
-      exitCode?: number | undefined
-      message: string
-      retryable?: boolean | undefined
-    }) => never
-    /** The resolved output format (e.g. `'toon'`, `'json'`, `'jsonl'`). */
-    format: Formatter.Format
-    /** Whether the user explicitly passed `--format` or `--json`. */
-    formatExplicit: boolean
-    /** The CLI name. */
-    name: string
-    /** Return a success result with optional metadata (e.g. CTAs). */
-    ok: (data: InferReturn<output>, meta?: { cta?: CtaBlock | undefined }) => never
-    options: InferOutput<options>
-    /** Variables set by middleware. */
-    var: InferVars<vars>
-    /** The CLI version string. */
-    version: string | undefined
-  }):
+  run(context: RunContext<args, env, options, output, vars, CtaBlock>):
     | InferReturn<output>
     | Promise<InferReturn<output>>
     | AsyncGenerator<InferReturn<output>, unknown, unknown>
@@ -2544,6 +2522,7 @@ function emitDeprecationWarnings(
   argv: string[],
   optionsSchema: z.ZodObject<any> | undefined,
   alias?: Record<string, string> | undefined,
+  stderr: (s: string) => void = (s) => process.stderr.write(s),
 ) {
   if (!optionsSchema) return
   const shape = optionsSchema.shape as Record<string, any>
@@ -2563,11 +2542,11 @@ function emitDeprecationWarnings(
       const stripped = token.split('=')[0]!.slice(2)
       const raw =
         !deprecatedFlags.has(stripped) && stripped.startsWith('no-') ? stripped.slice(3) : stripped
-      if (deprecatedFlags.has(raw)) process.stderr.write(`Warning: --${raw} is deprecated\n`)
+      if (deprecatedFlags.has(raw)) stderr(`Warning: --${raw} is deprecated\n`)
     } else if (token.startsWith('-') && token.length >= 2) {
       for (const ch of token.slice(1))
         if (deprecatedShorts.has(ch))
-          process.stderr.write(`Warning: --${deprecatedShorts.get(ch)} is deprecated\n`)
+          stderr(`Warning: --${deprecatedShorts.get(ch)} is deprecated\n`)
     }
   }
 }

--- a/src/internal/run.ts
+++ b/src/internal/run.ts
@@ -1,0 +1,114 @@
+import type { z } from 'zod'
+
+import type * as Formatter from '../Formatter.js'
+
+/** @internal Human-only output channel exposed to command handlers. */
+export type Human = {
+  /** Whether human output is currently active. */
+  enabled: boolean
+  /** Terminal stream for third-party TTY helpers when available. */
+  stream?: NodeJS.WriteStream | undefined
+  /** Writes raw text to the human-only channel. */
+  write(text: string): void
+  /** Writes a line to the human-only channel. */
+  writeln(text: string): void
+}
+
+/** @internal Full command context passed to `run()` handlers. */
+export type RunContext<
+  args extends z.ZodObject<any> | undefined,
+  env extends z.ZodObject<any> | undefined,
+  options extends z.ZodObject<any> | undefined,
+  output extends z.ZodType | undefined,
+  vars extends z.ZodObject<any> | undefined,
+  cta = unknown,
+> = {
+  /** Whether the consumer is an agent (stdout is not a TTY). */
+  agent: boolean
+  /** Positional arguments. */
+  args: InferOutput<args>
+  /** Parsed environment variables. */
+  env: InferOutput<env>
+  /** Return an error result with optional CTAs. */
+  error: (options: {
+    code: string
+    cta?: cta | undefined
+    exitCode?: number | undefined
+    message: string
+    retryable?: boolean | undefined
+  }) => never
+  /** The resolved output format (e.g. `'toon'`, `'json'`, `'jsonl'`). */
+  format: Formatter.Format
+  /** Whether the user explicitly passed `--format` or `--json`. */
+  formatExplicit: boolean
+  /** Human-only output helpers. */
+  human: Human
+  /** The CLI name. */
+  name: string
+  /** Return a success result with optional metadata (e.g. CTAs). */
+  ok: (data: InferReturn<output>, meta?: { cta?: cta | undefined }) => never
+  /** Parsed named options/flags. */
+  options: InferOutput<options>
+  /** Variables set by middleware. */
+  var: InferVars<vars>
+  /** The CLI version string. */
+  version: string | undefined
+}
+
+/** @internal Creates a stable human output helper that no-ops when disabled. */
+export function createHuman(options: createHuman.Options = {}): Human {
+  const { enabled = false, stream, write = noop } = options
+  if (!enabled) return { enabled: false, write: noop, writeln: noop }
+
+  const human = {
+    enabled: true,
+    write,
+    writeln(text: string) {
+      write(text.endsWith('\n') ? text : `${text}\n`)
+    },
+  }
+
+  if (!stream) return human
+  return { ...human, stream }
+}
+
+export declare namespace createHuman {
+  /** Options for `createHuman()`. */
+  type Options = {
+    /** Whether the human-only channel should emit output. */
+    enabled?: boolean | undefined
+    /** Live terminal stream for third-party UI helpers. */
+    stream?: NodeJS.WriteStream | undefined
+    /** Sink used for human-only writes. */
+    write?: ((text: string) => void) | undefined
+  }
+}
+
+/** @internal Returns the assembled `run()` context without further mutation. */
+export function createRunContext<
+  args extends z.ZodObject<any> | undefined,
+  env extends z.ZodObject<any> | undefined,
+  options extends z.ZodObject<any> | undefined,
+  output extends z.ZodType | undefined,
+  vars extends z.ZodObject<any> | undefined,
+  cta = unknown,
+>(
+  context: RunContext<args, env, options, output, vars, cta>,
+): RunContext<args, env, options, output, vars, cta> {
+  return context
+}
+
+/** @internal Inferred output type of a Zod schema, or `{}` when the schema is not provided. */
+type InferOutput<schema extends z.ZodObject<any> | undefined> =
+  schema extends z.ZodObject<any> ? z.output<schema> : {}
+
+/** @internal Inferred return type for a command handler. */
+type InferReturn<output extends z.ZodType | undefined> = output extends z.ZodType
+  ? z.output<output>
+  : unknown
+
+/** @internal Inferred vars type from a Zod schema, or `{}` when no schema is provided. */
+type InferVars<vars extends z.ZodObject<any> | undefined> =
+  vars extends z.ZodObject<any> ? z.output<vars> : {}
+
+function noop(_text: string) {}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod'
 
 import type * as Formatter from './Formatter.js'
+import type { Human } from './internal/run.js'
 
 /** @internal Infers the output type of a vars schema, or `{}` if undefined. */
 type InferVars<vars extends z.ZodObject<any> | undefined> =
@@ -47,6 +48,8 @@ export type Context<
   format: Formatter.Format
   /** Whether the user explicitly passed `--format` or `--json`. */
   formatExplicit: boolean
+  /** Human-only output helpers. */
+  human: Human
   /** The CLI name. */
   name: string
   /** Set a typed variable for downstream middleware and handlers. */


### PR DESCRIPTION
This PR proposes a dedicated human-only output channel for command execution via `c.human`.

Command implementations that use `console.log()` or other direct stdout writes can break structured output parsing, specifically in `run` and streaming `async *run` handlers. This change introduces `c.human` as a separate output surface for terminal-only UX like status messages, progress updates, and third-party spinner/progress integrations.

`c.human` is now available on both `run` and middleware contexts for consistency, with the following API:

- `c.human.enabled`
- `c.human.stream`
- `c.human.write(text)`
- `c.human.writeln(text)`

Human output is routed to `stderr` and safely no-ops when no human terminal is attached. This keeps structured stdout output unchanged while still allowing live terminal feedback. `c.agent` and `c.human.enabled` are intentionally independent, so commands can still emit human progress to stderr while stdout is piped or machine-consumed.

```ts
cli.command('deploy', {
  args: z.object({ env: z.enum(['staging', 'production']) }),
  run(c) {
    c.human.writeln(`Deploying to ${c.args.env}...`)
    // or use c.human.stream (WriteStream)
    return { url: `https://${c.args.env}.example.com` }
  },
})
```

## Follow Up

A possible follow-up is a `pretty` / `prettyStream` API as a complementary layer on top of structured output.

That model would let commands define a human-oriented formatter for returned values and streamed chunks, for example:

```ts
command('deploy', {
  run() {
    return { url: 'https://example.com', durationMs: 1200 }
  },
  pretty(data, c) {
    return `Deployed in ${data.durationMs}ms`
  },
})
```

and for streaming:

```ts
command('sync', {
  async *run() {
    yield { step: 1, total: 3 }
    yield { step: 2, total: 3 }
  },
  prettyStream(chunk, c) {
    return `Step ${chunk.step}/${chunk.total}`
  },
})
```

That would be useful for projecting structured data into a cleaner TTY view, while `c.human` remains the lower-level imperative channel for ephemeral UI like spinners, carriage-return updates, and progress messages before the first yielded chunk.

In that design, the split would be:

- `return` / `yield` for machine-readable output
- `pretty` / `prettyStream` for human rendering of structured data
- `c.human.*` for terminal-only side effects

Another possible future extension is a small built-in human-UX layer on top of c.human, for example:

- color helpers
- spinner/progress primitives
- a logger middleware built on the same human channel

That could look something like:

- `c.human.log.info(...)`
- `c.human.log.warn(...)`
- `c.human.color.dim(...)`
- `c.human.spinner({ text }).start()`

or as opt-in helpers/middleware exported from incur rather than methods directly on c.human.

The main reason to defer that is scope. Once `incur` starts shipping colors, spinners, and logging behavior, it has to make decisions about ANSI handling, nested spinners, verbosity, update frequency, and overall terminal UX. Those are useful features, but they are a different layer of abstraction than the basic channel separation introduced here. 

## Alternatives

### `if (!c.agent) console.log(...)`

This is the simplest alternative, but it has a few problems:

- It still writes human output to stdout
- It is easy for command authors to get wrong or forget and a `console.log()` can still corrupt machine-readable output
- It does not support the useful case where stdout is piped but stderr is still attached to a TTY. In that case, `c.agent` is `true`, but we may still want human progress on the terminal
- It does not give consumers a terminal stream they can hand to spinner or progress libraries

`c.human` is more explicit and safer because it separates output channels instead of relying on authors to manually guard stdout writes.

### `--format human`

Another alternative is a `human` format that prints output “as is”. Issues with that approach:

- It does not solve ephemeral UI like spinners, carriage-return updates, or status messages before the first returned value or yielded chunk
- It still encourages mixing human-oriented output with the main command output path rather than keeping structured output isolated
- It overloads `format` with two responsibilities: rendering structured data and controlling whether side-effect terminal UX is allowed
- It makes streaming semantics less clear, because “print everything as is” does not define how structured chunks and terminal-only progress should coexist

A `format=human` mode could still be useful as a presentation layer, but it does not replace the need for a separate human-only channel.