### PR TITLE
feat: compact `--llms` command index, full manifest moved to `--llms-full`

### DIFF
--- a/.changeset/llms-full-rename.md
+++ b/.changeset/llms-full-rename.md
@@ -1,0 +1,5 @@
+---
+"incur": minor
+---
+
+**Breaking:** Renamed `--llms` to `--llms-full`. Added a new `--llms` flag that outputs a compact command index (table of command signatures + descriptions) instead of the full manifest. This reduced token usage by ~95% for agents that already know the CLI and just need a quick reminder of available commands.

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -378,12 +378,12 @@ describe('serve', () => {
   })
 })
 
-describe('--llms', () => {
+describe('--llms-full', () => {
   test('outputs manifest with version and commands', async () => {
     const cli = Cli.create('test')
     cli.command('ping', { description: 'Health check', run: () => ({ pong: true }) })
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     const manifest = JSON.parse(output)
     expect(manifest.version).toBe('incur.v1')
     expect(manifest.commands).toHaveLength(1)
@@ -399,7 +399,7 @@ describe('--llms', () => {
       run: ({ args }) => ({ message: `hello ${args.name}` }),
     })
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     const manifest = JSON.parse(output)
     expect(manifest.commands[0].schema.args).toEqual({
       type: 'object',
@@ -423,7 +423,7 @@ describe('--llms', () => {
       run: ({ args }) => ({ message: `hello ${args.name}` }),
     })
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     const manifest = JSON.parse(output)
     expect(manifest.commands[0].schema.output).toEqual({
       type: 'object',
@@ -437,7 +437,7 @@ describe('--llms', () => {
     const cli = Cli.create('test')
     cli.command('ping', { run: () => ({ pong: true }) })
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     const manifest = JSON.parse(output)
     expect(manifest.commands[0].schema).toBeUndefined()
   })
@@ -457,7 +457,7 @@ describe('--llms', () => {
       })
     cli.command(pr)
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     const manifest = JSON.parse(output)
     expect(manifest.commands).toHaveLength(2)
     expect(manifest.commands[0].name).toBe('pr create')
@@ -474,7 +474,7 @@ describe('--llms', () => {
     pr.command(review)
     cli.command(pr)
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     const manifest = JSON.parse(output)
     expect(manifest.commands[0].name).toBe('pr review approve')
     expect(manifest.commands[0].description).toBe('Approve a review')
@@ -484,7 +484,7 @@ describe('--llms', () => {
     const cli = Cli.create('test')
     cli.command('ping', { description: 'Health check', run: () => ({ pong: true }) })
 
-    const { output } = await serve(cli, ['--llms'])
+    const { output } = await serve(cli, ['--llms-full'])
     expect(output).toContain('# test ping')
     expect(output).toContain('Health check')
   })
@@ -493,7 +493,7 @@ describe('--llms', () => {
     const cli = Cli.create('test')
     cli.command('ping', { description: 'Health check', run: () => ({ pong: true }) })
 
-    const { output } = await serve(cli, ['--llms', '--format', 'yaml'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'yaml'])
     expect(output).toContain('version: incur.v1')
     expect(output).toContain('name: ping')
   })
@@ -508,7 +508,7 @@ describe('--llms', () => {
       run: ({ args }) => ({ message: `hello ${args.name}` }),
     })
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     expect(JSON.parse(output)).toMatchInlineSnapshot(`
       {
         "commands": [
@@ -572,11 +572,74 @@ describe('--llms', () => {
       run: ({ args }) => ({ message: `hello ${args.name}` }),
     })
 
-    const { output } = await serve(cli, ['--llms', '--format', 'md'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'md'])
     expect(output).toContain('# test greet')
     expect(output).toContain('## Arguments')
     expect(output).toContain('## Output')
     expect(output).not.toMatch(/^---$/m)
+  })
+})
+
+describe('--llms', () => {
+  test('outputs compact command index', async () => {
+    const cli = Cli.create('test')
+    cli.command('ping', { description: 'Health check', run: () => ({}) })
+    cli.command('greet', {
+      description: 'Greet someone',
+      args: z.object({ name: z.string() }),
+      run: () => ({}),
+    })
+
+    const { output } = await serve(cli, ['--llms-full'])
+    expect(output).toMatchInlineSnapshot(`
+      "# test greet
+
+      Greet someone
+
+      ## Arguments
+
+      | Name | Type | Required | Description |
+      |------|------|----------|-------------|
+      | \`name\` | \`string\` | yes |  |
+
+      # test ping
+
+      Health check
+      "
+    `)
+  })
+
+  test('--llms --json strips schemas', async () => {
+    const cli = Cli.create('test')
+    cli.command('greet', {
+      description: 'Greet someone',
+      args: z.object({ name: z.string() }),
+      output: z.object({ message: z.string() }),
+      run: () => ({ message: 'hi' }),
+    })
+
+    const { output } = await serve(cli, ['--llms', '--json'])
+    const manifest = JSON.parse(output)
+    expect(manifest.version).toBe('incur.v1')
+    expect(manifest.commands).toHaveLength(1)
+    expect(manifest.commands[0].name).toBe('greet')
+    expect(manifest.commands[0].description).toBe('Greet someone')
+    expect(manifest.commands[0].schema).toBeUndefined()
+    expect(manifest.commands[0].examples).toBeUndefined()
+  })
+
+  test('scopes to subtree', async () => {
+    const cli = Cli.create('test')
+    const group = Cli.create('auth', { description: 'Authentication' })
+    group.command('login', { description: 'Log in', run: () => ({}) })
+    group.command('logout', { description: 'Log out', run: () => ({}) })
+    cli.command(group)
+    cli.command('ping', { description: 'Health check', run: () => ({}) })
+
+    const { output } = await serve(cli, ['auth', '--llms'])
+    expect(output).toContain('test auth auth login')
+    expect(output).toContain('test auth auth logout')
+    expect(output).not.toContain('ping')
   })
 })
 
@@ -857,7 +920,7 @@ describe('subcommands', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1261,7 +1324,7 @@ describe('leaf cli', () => {
     const cli = Cli.create('app')
     cli.command(ping)
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     const manifest = JSON.parse(output)
     expect(manifest.commands).toHaveLength(1)
     expect(manifest.commands[0].name).toBe('ping')
@@ -1296,7 +1359,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
@@ -1334,7 +1397,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
@@ -1368,7 +1431,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1402,7 +1465,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1497,7 +1560,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
@@ -1529,7 +1592,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1624,7 +1687,7 @@ describe('env', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1662,7 +1725,7 @@ describe('env', () => {
           --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
           --format <toon|json|yaml|md|jsonl>  Output format
           --help                              Show help
-          --llms                              Print LLM-readable manifest
+          --llms, --llms-full                 Print LLM-readable manifest
           --schema                            Show JSON Schema for a command
           --token-count                       Print token count of output (instead of output)
           --token-limit <n>                   Limit output to n tokens
@@ -1721,7 +1784,7 @@ describe('env', () => {
       },
     })
 
-    const { output } = await serve(cli, ['--llms', '--format', 'json'])
+    const { output } = await serve(cli, ['--llms-full', '--format', 'json'])
     const cmd = JSON.parse(output).commands.find((c: any) => c.name === 'deploy')
     expect(cmd.schema.env).toMatchInlineSnapshot(`
       {
@@ -1751,7 +1814,7 @@ describe('env', () => {
       },
     })
 
-    const { output } = await serve(cli, ['--llms'])
+    const { output } = await serve(cli, ['--llms-full'])
     expect(output).toContain('Environment Variables')
     expect(output).toContain('`API_TOKEN`')
   })
@@ -2495,7 +2558,7 @@ test('--llms scoped to leaf command', async () => {
   cli.command('ping', { description: 'Health check', run: () => ({ pong: true }) })
   cli.command('greet', { description: 'Greet someone', run: () => ({}) })
 
-  const { output } = await serve(cli, ['--llms', '--format', 'json', 'ping'])
+  const { output } = await serve(cli, ['--llms-full', '--format', 'json', 'ping'])
   const manifest = JSON.parse(output)
   expect(manifest.commands).toHaveLength(1)
   expect(manifest.commands[0].name).toBe('ping')
@@ -2509,7 +2572,7 @@ test('--llms scoped to group', async () => {
   cli.command(pr)
   cli.command('ping', { description: 'Health check', run: () => ({}) })
 
-  const { output } = await serve(cli, ['--llms', '--format', 'json', 'pr'])
+  const { output } = await serve(cli, ['--llms-full', '--format', 'json', 'pr'])
   const manifest = JSON.parse(output)
   expect(manifest.commands).toHaveLength(2)
   expect(manifest.commands.every((c: any) => c.name.startsWith('pr '))).toBe(true)
@@ -2711,7 +2774,7 @@ test('--llms includes hint in skill output', async () => {
     run: () => ({}),
   })
 
-  const { output } = await serve(cli, ['--llms'])
+  const { output } = await serve(cli, ['--llms-full'])
   expect(output).toContain('Always confirm before deploying to production')
 })
 
@@ -2904,7 +2967,7 @@ describe('fetch', async () => {
       description: 'Proxy to API',
       fetch: app.fetch,
     })
-    const { output } = await serve(cli, ['--llms'])
+    const { output } = await serve(cli, ['--llms-full'])
     expect(output).toContain('api')
     expect(output).toContain('Proxy to API')
   })

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -424,6 +424,7 @@ async function serveImpl(
     tokenOffset,
     tokenCount,
     llms,
+    llmsFull,
     mcp: mcpFlag,
     help,
     version,
@@ -464,7 +465,7 @@ async function serveImpl(
   }
 
   // Skills staleness check (skip for built-in commands)
-  if (!llms && !schema && !help && !version) {
+  if (!llms && !llmsFull && !schema && !help && !version) {
     const isSkillsAdd =
       filtered[0] === 'skills' || (filtered[0] === name && filtered[1] === 'skills')
     const isMcpAdd = filtered[0] === 'mcp' || (filtered[0] === name && filtered[1] === 'mcp')
@@ -484,15 +485,17 @@ async function serveImpl(
     }
   }
 
-  if (llms) {
+  if (llms || llmsFull) {
     // Scope to a subtree if command tokens are provided
     let scopedCommands = commands
     const prefix: string[] = []
+    let scopedDescription: string | undefined = options.description
     for (const token of filtered) {
       const entry = scopedCommands.get(token)
       if (!entry) break
       if (isGroup(entry)) {
         scopedCommands = entry.commands
+        scopedDescription = entry.description
         prefix.push(token)
       } else {
         // Leaf command — scope to just this command
@@ -501,14 +504,26 @@ async function serveImpl(
       }
     }
 
+    if (llmsFull) {
+      if (!formatExplicit || formatFlag === 'md') {
+        const groups = new Map<string, string>()
+        const cmds = collectSkillCommands(scopedCommands, prefix, groups)
+        const scopedName = prefix.length > 0 ? `${name} ${prefix.join(' ')}` : name
+        writeln(Skill.generate(scopedName, cmds, groups))
+        return
+      }
+      writeln(Formatter.format(buildManifest(scopedCommands, prefix), formatFlag))
+      return
+    }
+
     if (!formatExplicit || formatFlag === 'md') {
       const groups = new Map<string, string>()
       const cmds = collectSkillCommands(scopedCommands, prefix, groups)
       const scopedName = prefix.length > 0 ? `${name} ${prefix.join(' ')}` : name
-      writeln(Skill.generate(scopedName, cmds, groups))
+      writeln(Skill.index(scopedName, cmds, scopedDescription))
       return
     }
-    writeln(Formatter.format(buildManifest(scopedCommands, prefix), formatFlag))
+    writeln(Formatter.format(buildIndexManifest(scopedCommands, prefix), formatFlag))
     return
   }
 
@@ -1800,6 +1815,7 @@ declare namespace serveImpl {
 function extractBuiltinFlags(argv: string[]) {
   let verbose = false
   let llms = false
+  let llmsFull = false
   let mcp = false
   let help = false
   let version = false
@@ -1816,6 +1832,7 @@ function extractBuiltinFlags(argv: string[]) {
     const token = argv[i]!
     if (token === '--verbose') verbose = true
     else if (token === '--llms') llms = true
+    else if (token === '--llms-full') llmsFull = true
     else if (token === '--mcp') mcp = true
     else if (token === '--help' || token === '-h') help = true
     else if (token === '--version') version = true
@@ -1840,7 +1857,7 @@ function extractBuiltinFlags(argv: string[]) {
     else rest.push(token)
   }
 
-  return { verbose, format, formatExplicit, filterOutput, tokenLimit, tokenOffset, tokenCount, llms, mcp, help, version, schema, rest }
+  return { verbose, format, formatExplicit, filterOutput, tokenLimit, tokenOffset, tokenCount, llms, llmsFull, mcp, help, version, schema, rest }
 }
 
 /** @internal Collects immediate child commands/groups for help output. */
@@ -2221,6 +2238,35 @@ function formatCta(name: string, cta: Cta): FormattedCta {
     for (const [key, value] of Object.entries(cta.options))
       cmd += value === true ? ` --${key} <${key}>` : ` --${key} ${value}`
   return { command: cmd, ...(cta.description ? { description: cta.description } : undefined) }
+}
+
+/** @internal Builds the `--llms` index manifest (name + description only) from the command tree. */
+function buildIndexManifest(commands: Map<string, CommandEntry>, prefix: string[] = []) {
+  return {
+    version: 'incur.v1',
+    commands: collectIndexCommands(commands, prefix).sort((a, b) => a.name.localeCompare(b.name)),
+  }
+}
+
+/** @internal Recursively collects leaf commands with name + description only. */
+function collectIndexCommands(
+  commands: Map<string, CommandEntry>,
+  prefix: string[],
+): { name: string; description?: string | undefined }[] {
+  const result: { name: string; description?: string | undefined }[] = []
+  for (const [name, entry] of commands) {
+    const path = [...prefix, name]
+    if (isGroup(entry)) {
+      result.push(...collectIndexCommands(entry.commands, path))
+    } else {
+      const cmd: (typeof result)[number] = { name: path.join(' ') }
+      if (isFetchGateway(entry)) {
+        if (entry.description) cmd.description = entry.description
+      } else if (entry.description) cmd.description = entry.description
+      result.push(cmd)
+    }
+  }
+  return result
 }
 
 /** @internal Builds the `--llms` manifest from the command tree. */

--- a/src/Help.test.ts
+++ b/src/Help.test.ts
@@ -28,7 +28,7 @@ describe('formatCommand', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -50,7 +50,7 @@ describe('formatCommand', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -79,7 +79,7 @@ describe('formatCommand', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -125,7 +125,7 @@ describe('formatRoot', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -150,7 +150,7 @@ describe('formatRoot', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -179,7 +179,7 @@ describe('formatRoot', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -208,7 +208,7 @@ describe('formatRoot', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens

--- a/src/Help.ts
+++ b/src/Help.ts
@@ -329,7 +329,7 @@ function globalOptionsLines(root = false): string[] {
     { flag: '--filter-output <keys>', desc: 'Filter output by key paths (e.g. foo,bar.baz,a[0,3])' },
     { flag: '--format <toon|json|yaml|md|jsonl>', desc: 'Output format' },
     { flag: '--help', desc: 'Show help' },
-    { flag: '--llms', desc: 'Print LLM-readable manifest' },
+    { flag: '--llms, --llms-full', desc: 'Print LLM-readable manifest' },
     ...(root ? [{ flag: '--mcp', desc: 'Start as MCP stdio server' }] : []),
     { flag: '--schema', desc: 'Show JSON Schema for a command' },
     { flag: '--token-count', desc: 'Print token count of output (instead of output)' },

--- a/src/Skill.test.ts
+++ b/src/Skill.test.ts
@@ -145,6 +145,41 @@ test('concatenates multiple commands', () => {
   `)
 })
 
+describe('index', () => {
+  test('generates compact command index', () => {
+    const result = Skill.index('test', [
+      { name: 'ping', description: 'Health check' },
+      { name: 'greet', description: 'Greet someone', args: z.object({ name: z.string() }) },
+    ])
+    expect(result).toMatchInlineSnapshot(`
+      "# test
+
+      | Command | Description |
+      |---------|-------------|
+      | \`test ping\` | Health check |
+      | \`test greet <name>\` | Greet someone |
+
+      Run \`test --llms-full\` for full manifest. Run \`test <command> --schema\` for argument details."
+    `)
+  })
+
+  test('uses brackets for optional args', () => {
+    const result = Skill.index('test', [
+      {
+        name: 'install',
+        description: 'Install a package',
+        args: z.object({ package: z.string().optional() }),
+      },
+    ])
+    expect(result).toContain('`test install [package]`')
+  })
+
+  test('handles commands without descriptions', () => {
+    const result = Skill.index('test', [{ name: 'ping' }])
+    expect(result).toContain('| `test ping` |  |')
+  })
+})
+
 describe('hash', () => {
   test('returns consistent hash for same commands', () => {
     const commands: Skill.CommandInfo[] = [

--- a/src/Skill.ts
+++ b/src/Skill.ts
@@ -23,6 +23,33 @@ export type File = {
   content: string
 }
 
+/** Generates a compact Markdown command index for `--llms`. */
+export function index(name: string, commands: CommandInfo[], description?: string | undefined): string {
+  const lines: string[] = [`# ${name}`]
+  if (description) lines.push('', description)
+  lines.push('')
+  lines.push('| Command | Description |')
+  lines.push('|---------|-------------|')
+  for (const cmd of commands) {
+    const signature = buildSignature(name, cmd)
+    const desc = cmd.description ?? ''
+    lines.push(`| \`${signature}\` | ${desc} |`)
+  }
+  lines.push('', `Run \`${name} --llms-full\` for full manifest. Run \`${name} <command> --schema\` for argument details.`)
+  return lines.join('\n')
+}
+
+/** @internal Builds a command signature with arg placeholders. */
+function buildSignature(cli: string, cmd: CommandInfo): string {
+  const base = `${cli} ${cmd.name}`
+  if (!cmd.args) return base
+  const shape = cmd.args.shape as Record<string, z.ZodType>
+  const json = Schema.toJsonSchema(cmd.args)
+  const required = new Set((json.required as string[] | undefined) ?? [])
+  const argNames = Object.keys(shape).map((k) => (required.has(k) ? `<${k}>` : `[${k}]`))
+  return `${base} ${argNames.join(' ')}`
+}
+
 /** Generates a Markdown skill file from a CLI name and collected command data. */
 export function generate(
   name: string,

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -939,7 +939,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
@@ -973,7 +973,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1000,7 +1000,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1026,7 +1026,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1058,7 +1058,7 @@ describe('help', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1090,9 +1090,9 @@ describe('help', () => {
   })
 })
 
-describe('--llms', () => {
+describe('--llms-full', () => {
   test('json manifest lists all leaf commands sorted', async () => {
-    const { output } = await serve(createApp(), ['--llms', '--format', 'json'])
+    const { output } = await serve(createApp(), ['--llms-full', '--format', 'json'])
     const manifest = json(output)
     expect(manifest.version).toBe('incur.v1')
     const names = manifest.commands.map((c: any) => c.name)
@@ -1127,7 +1127,7 @@ describe('--llms', () => {
   })
 
   test('manifest includes schema.args and schema.options separately', async () => {
-    const { output } = await serve(createApp(), ['--llms', '--format', 'json'])
+    const { output } = await serve(createApp(), ['--llms-full', '--format', 'json'])
     const projectList = json(output).commands.find((c: any) => c.name === 'project list')
     expect(projectList.schema.options.properties).toMatchInlineSnapshot(`
       {
@@ -1157,7 +1157,7 @@ describe('--llms', () => {
   })
 
   test('manifest includes schema.output', async () => {
-    const { output } = await serve(createApp(), ['--llms', '--format', 'json'])
+    const { output } = await serve(createApp(), ['--llms-full', '--format', 'json'])
     const projectGet = json(output).commands.find((c: any) => c.name === 'project get')
     expect(projectGet.schema.output).toMatchInlineSnapshot(`
       {
@@ -1204,13 +1204,13 @@ describe('--llms', () => {
   })
 
   test('manifest omits schema when no schemas defined', async () => {
-    const { output } = await serve(createApp(), ['--llms', '--format', 'json'])
+    const { output } = await serve(createApp(), ['--llms-full', '--format', 'json'])
     const ping = json(output).commands.find((c: any) => c.name === 'ping')
     expect(ping.schema).toBeUndefined()
   })
 
-  test('scoped --llms to group', async () => {
-    const { output } = await serve(createApp(), ['auth', '--llms', '--format', 'json'])
+  test('scoped --llms-full to group', async () => {
+    const { output } = await serve(createApp(), ['auth', '--llms-full', '--format', 'json'])
     const names = json(output).commands.map((c: any) => c.name)
     expect(names).toMatchInlineSnapshot(`
       [
@@ -1221,8 +1221,8 @@ describe('--llms', () => {
     `)
   })
 
-  test('scoped --llms to nested group', async () => {
-    const { output } = await serve(createApp(), ['project', 'deploy', '--llms', '--format', 'json'])
+  test('scoped --llms-full to nested group', async () => {
+    const { output } = await serve(createApp(), ['project', 'deploy', '--llms-full', '--format', 'json'])
     const names = json(output).commands.map((c: any) => c.name)
     expect(names).toMatchInlineSnapshot(`
       [
@@ -1233,27 +1233,27 @@ describe('--llms', () => {
     `)
   })
 
-  test('default --llms outputs markdown', async () => {
-    const { output } = await serve(createApp(), ['--llms'])
+  test('default --llms-full outputs markdown', async () => {
+    const { output } = await serve(createApp(), ['--llms-full'])
     expect(output).toContain('# app')
     expect(output).toContain('auth login')
     expect(output).toContain('project list')
   })
 
-  test('--llms markdown includes argument tables', async () => {
-    const { output } = await serve(createApp(), ['project', '--llms'])
+  test('--llms-full markdown includes argument tables', async () => {
+    const { output } = await serve(createApp(), ['project', '--llms-full'])
     expect(output).toContain('Arguments')
     expect(output).toContain('`id`')
   })
 
-  test('--llms markdown includes options tables', async () => {
-    const { output } = await serve(createApp(), ['project', '--llms'])
+  test('--llms-full markdown includes options tables', async () => {
+    const { output } = await serve(createApp(), ['project', '--llms-full'])
     expect(output).toContain('Options')
     expect(output).toContain('`--limit`')
   })
 
-  test('--llms json includes examples on commands', async () => {
-    const { output } = await serve(createApp(), ['project', 'deploy', '--llms', '--format', 'json'])
+  test('--llms-full json includes examples on commands', async () => {
+    const { output } = await serve(createApp(), ['project', 'deploy', '--llms-full', '--format', 'json'])
     const deployCreate = json(output).commands.find((c: any) => c.name === 'project deploy create')
     expect(deployCreate.examples).toMatchInlineSnapshot(`
       [
@@ -1269,27 +1269,268 @@ describe('--llms', () => {
     `)
   })
 
-  test('--llms json omits examples when not defined', async () => {
-    const { output } = await serve(createApp(), ['--llms', '--format', 'json'])
+  test('--llms-full json omits examples when not defined', async () => {
+    const { output } = await serve(createApp(), ['--llms-full', '--format', 'json'])
     const ping = json(output).commands.find((c: any) => c.name === 'ping')
     expect(ping.examples).toBeUndefined()
   })
 
-  test('--llms markdown includes examples section', async () => {
-    const { output } = await serve(createApp(), ['--llms'])
+  test('--llms-full markdown includes examples section', async () => {
+    const { output } = await serve(createApp(), ['--llms-full'])
     expect(output).toContain('Examples')
     expect(output).toContain('Deploy staging from main')
     expect(output).toContain('app project deploy create staging')
   })
 
-  test('--llms markdown includes output tables', async () => {
-    const { output } = await serve(createApp(), ['project', '--llms'])
+  test('--llms-full markdown includes output tables', async () => {
+    const { output } = await serve(createApp(), ['project', '--llms-full'])
     expect(output).toContain('Output')
+  })
+
+  test('--llms-full --format yaml', async () => {
+    const { output } = await serve(createApp(), ['--llms-full', '--format', 'yaml'])
+    expect(output).toContain('version: incur.v1')
+  })
+})
+
+describe('--llms', () => {
+  test('outputs compact markdown table with all commands', async () => {
+    const { output } = await serve(createApp(), ['--llms'])
+    expect(output).toMatchInlineSnapshot(`
+      "# app
+
+      A comprehensive CLI application for testing.
+
+      | Command | Description |
+      |---------|-------------|
+      | \`app api\` | Proxy to HTTP API |
+      | \`app auth login\` | Log in to the service |
+      | \`app auth logout\` | Log out of the service |
+      | \`app auth status\` | Show authentication status |
+      | \`app config [key]\` | Show current configuration |
+      | \`app echo <message> [repeat]\` | Echo back arguments |
+      | \`app explode\` | Always fails |
+      | \`app explode-clac\` | Fails with IncurError |
+      | \`app noop\` | Returns nothing |
+      | \`app ping\` | Health check |
+      | \`app project create <name>\` | Create a new project |
+      | \`app project delete <id>\` | Delete a project |
+      | \`app project deploy create <env>\` | Create a deployment |
+      | \`app project deploy rollback <deployId>\` | Rollback a deployment |
+      | \`app project deploy status <deployId>\` | Check deployment status |
+      | \`app project get <id>\` | Get a project by ID |
+      | \`app project list\` | List projects |
+      | \`app slow\` | Async command |
+      | \`app stream\` | Stream chunks |
+      | \`app stream-error\` | Stream with mid-stream error |
+      | \`app stream-ok\` | Stream with ok() return |
+      | \`app stream-text\` | Stream plain text |
+      | \`app stream-throw\` | Stream that throws |
+      | \`app validate-fail <email> <age>\` | Fails validation |
+
+      Run \`app --llms-full\` for full manifest. Run \`app <command> --schema\` for argument details.
+      "
+    `)
+  })
+
+  test('json manifest has name + description only, no schema/examples', async () => {
+    const { output } = await serve(createApp(), ['--llms', '--format', 'json'])
+    expect(json(output)).toMatchInlineSnapshot(`
+      {
+        "commands": [
+          {
+            "description": "Proxy to HTTP API",
+            "name": "api",
+          },
+          {
+            "description": "Log in to the service",
+            "name": "auth login",
+          },
+          {
+            "description": "Log out of the service",
+            "name": "auth logout",
+          },
+          {
+            "description": "Show authentication status",
+            "name": "auth status",
+          },
+          {
+            "description": "Show current configuration",
+            "name": "config",
+          },
+          {
+            "description": "Echo back arguments",
+            "name": "echo",
+          },
+          {
+            "description": "Always fails",
+            "name": "explode",
+          },
+          {
+            "description": "Fails with IncurError",
+            "name": "explode-clac",
+          },
+          {
+            "description": "Returns nothing",
+            "name": "noop",
+          },
+          {
+            "description": "Health check",
+            "name": "ping",
+          },
+          {
+            "description": "Create a new project",
+            "name": "project create",
+          },
+          {
+            "description": "Delete a project",
+            "name": "project delete",
+          },
+          {
+            "description": "Create a deployment",
+            "name": "project deploy create",
+          },
+          {
+            "description": "Rollback a deployment",
+            "name": "project deploy rollback",
+          },
+          {
+            "description": "Check deployment status",
+            "name": "project deploy status",
+          },
+          {
+            "description": "Get a project by ID",
+            "name": "project get",
+          },
+          {
+            "description": "List projects",
+            "name": "project list",
+          },
+          {
+            "description": "Async command",
+            "name": "slow",
+          },
+          {
+            "description": "Stream chunks",
+            "name": "stream",
+          },
+          {
+            "description": "Stream with mid-stream error",
+            "name": "stream-error",
+          },
+          {
+            "description": "Stream with ok() return",
+            "name": "stream-ok",
+          },
+          {
+            "description": "Stream plain text",
+            "name": "stream-text",
+          },
+          {
+            "description": "Stream that throws",
+            "name": "stream-throw",
+          },
+          {
+            "description": "Fails validation",
+            "name": "validate-fail",
+          },
+        ],
+        "version": "incur.v1",
+      }
+    `)
+  })
+
+  test('scoped to group', async () => {
+    const { output } = await serve(createApp(), ['auth', '--llms'])
+    expect(output).toMatchInlineSnapshot(`
+      "# app auth
+
+      Authentication commands
+
+      | Command | Description |
+      |---------|-------------|
+      | \`app auth auth login\` | Log in to the service |
+      | \`app auth auth logout\` | Log out of the service |
+      | \`app auth auth status\` | Show authentication status |
+
+      Run \`app auth --llms-full\` for full manifest. Run \`app auth <command> --schema\` for argument details.
+      "
+    `)
+  })
+
+  test('scoped to nested group', async () => {
+    const { output } = await serve(createApp(), ['project', 'deploy', '--llms'])
+    expect(output).toMatchInlineSnapshot(`
+      "# app project deploy
+
+      Deployment commands
+
+      | Command | Description |
+      |---------|-------------|
+      | \`app project deploy project deploy create <env>\` | Create a deployment |
+      | \`app project deploy project deploy rollback <deployId>\` | Rollback a deployment |
+      | \`app project deploy project deploy status <deployId>\` | Check deployment status |
+
+      Run \`app project deploy --llms-full\` for full manifest. Run \`app project deploy <command> --schema\` for argument details.
+      "
+    `)
   })
 
   test('--llms --format yaml', async () => {
     const { output } = await serve(createApp(), ['--llms', '--format', 'yaml'])
-    expect(output).toContain('version: incur.v1')
+    expect(output).toMatchInlineSnapshot(`
+      "version: incur.v1
+      commands:
+        - name: api
+          description: Proxy to HTTP API
+        - name: auth login
+          description: Log in to the service
+        - name: auth logout
+          description: Log out of the service
+        - name: auth status
+          description: Show authentication status
+        - name: config
+          description: Show current configuration
+        - name: echo
+          description: Echo back arguments
+        - name: explode
+          description: Always fails
+        - name: explode-clac
+          description: Fails with IncurError
+        - name: noop
+          description: Returns nothing
+        - name: ping
+          description: Health check
+        - name: project create
+          description: Create a new project
+        - name: project delete
+          description: Delete a project
+        - name: project deploy create
+          description: Create a deployment
+        - name: project deploy rollback
+          description: Rollback a deployment
+        - name: project deploy status
+          description: Check deployment status
+        - name: project get
+          description: Get a project by ID
+        - name: project list
+          description: List projects
+        - name: slow
+          description: Async command
+        - name: stream
+          description: Stream chunks
+        - name: stream-error
+          description: Stream with mid-stream error
+        - name: stream-ok
+          description: Stream with ok() return
+        - name: stream-text
+          description: Stream plain text
+        - name: stream-throw
+          description: Stream that throws
+        - name: validate-fail
+          description: Fails validation
+      "
+    `)
   })
 })
 
@@ -1461,7 +1702,7 @@ describe('root command with subcommands', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --mcp                               Start as MCP stdio server
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
@@ -1638,7 +1879,7 @@ describe('env', () => {
         --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
         --format <toon|json|yaml|md|jsonl>  Output format
         --help                              Show help
-        --llms                              Print LLM-readable manifest
+        --llms, --llms-full                 Print LLM-readable manifest
         --schema                            Show JSON Schema for a command
         --token-count                       Print token count of output (instead of output)
         --token-limit <n>                   Limit output to n tokens
@@ -1652,8 +1893,8 @@ describe('env', () => {
     `)
   })
 
-  test('--llms json includes schema.env', async () => {
-    const { output } = await serve(createApp(), ['auth', '--llms', '--format', 'json'])
+  test('--llms-full json includes schema.env', async () => {
+    const { output } = await serve(createApp(), ['auth', '--llms-full', '--format', 'json'])
     const login = json(output).commands.find((c: any) => c.name === 'auth login')
     expect(login.schema.env.properties).toMatchInlineSnapshot(`
       {
@@ -1670,8 +1911,8 @@ describe('env', () => {
     `)
   })
 
-  test('--llms markdown includes env vars table', async () => {
-    const { output } = await serve(createApp(), ['auth', '--llms'])
+  test('--llms-full markdown includes env vars table', async () => {
+    const { output } = await serve(createApp(), ['auth', '--llms-full'])
     expect(output).toContain('Environment Variables')
     expect(output).toContain('`AUTH_TOKEN`')
     expect(output).toContain('`AUTH_HOST`')


### PR DESCRIPTION
## Summary

**Breaking:** `--llms` now outputs a compact command index instead of the full manifest. The full manifest moved to `--llms-full`.

Closes #54.

## Changes

- `--llms` outputs a compact Markdown table (command signatures + descriptions) — ~95% token reduction
- `--llms-full` outputs the previous full manifest with schemas, env vars, examples
- Footer on `--llms` output guides agents to `--llms-full` and `<command> --schema`
- `--help` shows both flags on one line: `--llms, --llms-full`
- Supports `--format json/yaml/toon` for both modes

## Example

```
$ npm --llms
# npm

The package manager for JavaScript.

| Command | Description |
|---------|-------------|
| \`npm info <package>\` | View registry info for a package |
| \`npm init\` | Create a package.json file |
| \`npm install [package]\` | Install a package |
| \`npm outdated\` | Check for outdated packages |
| \`npm publish\` | Publish a package to the registry |
| \`npm run <script>\` | Run a script defined in package.json |
| \`npm uninstall <package>\` | Remove a package |

Run \`npm --llms-full\` for full manifest. Run \`npm <command> --schema\` for argument details.
```

**11 lines vs 219 lines** for the same CLI.

## Tests

- Unit tests for `Skill.index()` (3 tests)
- Integration tests for `--llms` in `Cli.test.ts` (3 tests)
- E2e tests with inline snapshots (5 tests): full output, JSON, scoped group, nested group, YAML
- All 697 tests pass