### PR TITLE
fix: skip npx prefix for globally installed binaries in MCP registration

### DIFF
--- a/.changeset/fix-mcp-global-registration.md
+++ b/.changeset/fix-mcp-global-registration.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Fixed MCP registration command detection for global, local, and source-launched CLIs.

--- a/src/SyncMcp.test.ts
+++ b/src/SyncMcp.test.ts
@@ -123,6 +123,57 @@ test('register with agents: ["amp"] skips add-mcp', async () => {
   expect(result.agents).toEqual(['Amp'])
 })
 
+test('register handles quoted command paths with spaces', async () => {
+  const { execFile } = await import('node:child_process')
+  vi.mocked(execFile).mockClear()
+
+  const result = await register('my-cli', {
+    command: '"/path/to my/cli" --mcp',
+    agents: ['amp'],
+  })
+
+  expect(result.agents).toEqual(['Amp'])
+
+  const configPath = join(fakeHome!, '.config', 'amp', 'settings.json')
+  const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+  expect(config['amp.mcpServers']['my-cli']).toEqual({
+    command: '/path/to my/cli',
+    args: ['--mcp'],
+  })
+})
+
+test('register uses bare name for global binary installs', async () => {
+  // Simulate global install: argv[1] is outside node_modules
+  process.argv[1] = '/usr/local/bin/my-cli'
+
+  const { execFile } = await import('node:child_process')
+  vi.mocked(execFile).mockClear()
+
+  const result = await register('my-cli', { agents: ['amp'] })
+
+  expect(result.command).toBe('my-cli --mcp')
+
+  const configPath = join(fakeHome!, '.config', 'amp', 'settings.json')
+  const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+  expect(config['amp.mcpServers']['my-cli']).toEqual({
+    command: 'my-cli',
+    args: ['--mcp'],
+  })
+})
+
+test('register uses runner for node_modules installs', async () => {
+  process.argv[1] = join(tmp, 'node_modules', '.bin', 'my-cli')
+
+  const { execFile } = await import('node:child_process')
+  vi.mocked(execFile).mockClear()
+
+  const result = await register('my-cli', { agents: ['amp'] })
+
+  // Should include the runner prefix (npx by default)
+  expect(result.command).toMatch(/^npx\s/)
+  expect(result.command).toContain('--mcp')
+})
+
 test('register writes amp config to existing settings', async () => {
   const configDir = join(fakeHome!, '.config', 'amp')
   mkdirSync(configDir, { recursive: true })

--- a/src/SyncMcp.test.ts
+++ b/src/SyncMcp.test.ts
@@ -169,8 +169,8 @@ test('register uses runner for node_modules installs', async () => {
 
   const result = await register('my-cli', { agents: ['amp'] })
 
-  // Should include the runner prefix (npx by default)
-  expect(result.command).toMatch(/^npx\s/)
+  // Should include a runner prefix (npx, pnpx, or bunx)
+  expect(result.command).toMatch(/^(npx|pnpx|bunx)\s/)
   expect(result.command).toContain('--mcp')
 })
 

--- a/src/SyncMcp.test.ts
+++ b/src/SyncMcp.test.ts
@@ -143,7 +143,6 @@ test('register handles quoted command paths with spaces', async () => {
 })
 
 test('register uses bare name for global binary installs', async () => {
-  // Simulate global install: argv[1] is outside node_modules
   process.argv[1] = '/usr/local/bin/my-cli'
 
   const { execFile } = await import('node:child_process')
@@ -159,6 +158,45 @@ test('register uses bare name for global binary installs', async () => {
     command: 'my-cli',
     args: ['--mcp'],
   })
+})
+
+test('register uses runner for source entrypoints outside node_modules', async () => {
+  process.argv[1] = join(tmp, 'dist', 'bin.js')
+
+  const { execFile } = await import('node:child_process')
+  vi.mocked(execFile).mockClear()
+
+  const result = await register('my-cli', { agents: ['amp'] })
+
+  expect(result.command).toMatch(/^(npx|pnpx|bunx)\s/)
+  expect(result.command).toContain('my-cli --mcp')
+})
+
+test('register uses bare name for global package entrypoints under node_modules', async () => {
+  process.argv[1] = join(tmp, 'global', 'node_modules', 'my-cli', 'dist', 'bin.js')
+
+  const { execFile } = await import('node:child_process')
+  vi.mocked(execFile).mockClear()
+
+  const result = await register('my-cli', { agents: ['amp'] })
+
+  expect(result.command).toBe('my-cli --mcp')
+})
+
+test('register uses runner for project dev dependency entrypoints under node_modules', async () => {
+  writeFileSync(
+    join(tmp, 'package.json'),
+    JSON.stringify({ devDependencies: { 'my-cli': '1.0.0' } }),
+  )
+  process.argv[1] = join(tmp, 'node_modules', 'my-cli', 'dist', 'bin.js')
+
+  const { execFile } = await import('node:child_process')
+  vi.mocked(execFile).mockClear()
+
+  const result = await register('my-cli', { agents: ['amp'] })
+
+  expect(result.command).toMatch(/^(npx|pnpx|bunx)\s/)
+  expect(result.command).toContain('my-cli --mcp')
 })
 
 test('register uses runner for node_modules installs', async () => {

--- a/src/SyncMcp.ts
+++ b/src/SyncMcp.ts
@@ -10,8 +10,10 @@ export async function register(
   name: string,
   options: register.Options = {},
 ): Promise<register.Result> {
+  const isGlobalBinary = !process.argv[1]?.match(/node_modules[/\\]/)
   const runner = detectRunner()
-  const command = options.command ?? `${runner} ${detectPackageSpecifier(name)} --mcp`
+  const command = options.command
+    ?? (isGlobalBinary ? `${name} --mcp` : `${runner} ${detectPackageSpecifier(name)} --mcp`)
   const targetAgents = options.agents ?? []
   const ampOnly = targetAgents.length === 1 && targetAgents[0] === 'amp'
 
@@ -64,7 +66,7 @@ function registerAmp(name: string, command: string): boolean {
     }
   }
 
-  const [cmd, ...args] = command.split(' ')
+  const [cmd, ...args] = splitCommand(command)
   if (!cmd) return false
 
   const servers: Record<string, any> = config['amp.mcpServers'] ?? {}
@@ -117,6 +119,30 @@ export function detectPackageSpecifier(name: string): string {
   } catch {}
 
   return name
+}
+
+/** Splits a command string into tokens, respecting single and double quotes. */
+function splitCommand(input: string): string[] {
+  const tokens: string[] = []
+  let current = ''
+  let quote: string | null = null
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]!
+    if (quote) {
+      if (ch === quote) quote = null
+      else current += ch
+    } else if (ch === '"' || ch === "'") {
+      quote = ch
+    } else if (ch === ' ') {
+      if (current) tokens.push(current)
+      current = ''
+    } else {
+      current += ch
+    }
+  }
+  if (current) tokens.push(current)
+  return tokens
 }
 
 /** Promisified execFile with stderr in error message. */

--- a/src/SyncMcp.ts
+++ b/src/SyncMcp.ts
@@ -10,10 +10,9 @@ export async function register(
   name: string,
   options: register.Options = {},
 ): Promise<register.Result> {
-  const isGlobalBinary = !process.argv[1]?.match(/node_modules[/\\]/)
   const runner = detectRunner()
   const command = options.command
-    ?? (isGlobalBinary ? `${name} --mcp` : `${runner} ${detectPackageSpecifier(name)} --mcp`)
+    ?? (nodeModulesRoot() ? `${runner} ${detectPackageSpecifier(name)} --mcp` : `${name} --mcp`)
   const targetAgents = options.agents ?? []
   const ampOnly = targetAgents.length === 1 && targetAgents[0] === 'amp'
 
@@ -100,16 +99,19 @@ export declare namespace register {
   }
 }
 
+/** @internal Returns the node_modules root path if running from a local install, or `null` for global installs. */
+function nodeModulesRoot(): string | null {
+  const match = process.argv[1]?.match(/^(.+)[/\\]node_modules[/\\]/)
+  return match?.[1] ?? null
+}
+
 /** @internal Detects the package specifier used to run this CLI (handles dlx/npx URL and version installs). */
 export function detectPackageSpecifier(name: string): string {
-  const bin = process.argv[1]
-  if (!bin) return name
-
-  const match = bin.match(/^(.+)[/\\]node_modules[/\\]/)
-  if (!match) return name
+  const root = nodeModulesRoot()
+  if (!root) return name
 
   try {
-    const pkg = JSON.parse(readFileSync(join(match[1]!, 'package.json'), 'utf-8'))
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'))
     const deps = pkg.dependencies ?? {}
     const spec = deps[name]
     if (!spec || Object.keys(deps).length !== 1) return name

--- a/src/SyncMcp.ts
+++ b/src/SyncMcp.ts
@@ -11,8 +11,7 @@ export async function register(
   options: register.Options = {},
 ): Promise<register.Result> {
   const runner = detectRunner()
-  const command = options.command
-    ?? (nodeModulesRoot() ? `${runner} ${detectPackageSpecifier(name)} --mcp` : `${name} --mcp`)
+  const command = options.command ?? defaultCommand(name, runner)
   const targetAgents = options.agents ?? []
   const ampOnly = targetAgents.length === 1 && targetAgents[0] === 'amp'
 
@@ -99,19 +98,56 @@ export declare namespace register {
   }
 }
 
-/** @internal Returns the node_modules root path if running from a local install, or `null` for global installs. */
-function nodeModulesRoot(): string | null {
-  const match = process.argv[1]?.match(/^(.+)[/\\]node_modules[/\\]/)
-  return match?.[1] ?? null
+/** @internal Builds the default MCP command for the current launch mode. */
+function defaultCommand(name: string, runner: string): string {
+  return shouldUseBareCommand(name)
+    ? `${name} --mcp`
+    : `${runner} ${detectPackageSpecifier(name)} --mcp`
+}
+
+/** @internal Returns node_modules path details for the current entrypoint. */
+function nodeModulesInfo(): { entry: string; root: string } | null {
+  const normalized = process.argv[1]?.replace(/\\/g, '/')
+  const match = normalized?.match(/^(.+)\/node_modules\/(.+)$/)
+  if (!match) return null
+  return { root: match[1]!, entry: match[2]! }
+}
+
+/** @internal Uses the bare command only when the binary is expected on PATH. */
+function shouldUseBareCommand(name: string): boolean {
+  const bin = process.argv[1]
+  if (!bin) return false
+
+  const info = nodeModulesInfo()
+  if (info) return !info.entry.startsWith('.bin/') && !packageDependsOn(info.root, name)
+
+  const file = bin.replace(/\\/g, '/').split('/').pop()
+  return file === name || file === `${name}.cmd` || file === `${name}.ps1`
+}
+
+/** @internal Checks whether the entrypoint came from a project dependency install. */
+function packageDependsOn(root: string, name: string): boolean {
+  try {
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'))
+    const dependencyFields = [
+      pkg.dependencies,
+      pkg.devDependencies,
+      pkg.optionalDependencies,
+      pkg.peerDependencies,
+    ]
+    return dependencyFields.some((dependencies) => name in (dependencies ?? {}))
+  } catch {
+    return false
+  }
 }
 
 /** @internal Detects the package specifier used to run this CLI (handles dlx/npx URL and version installs). */
 export function detectPackageSpecifier(name: string): string {
-  const root = nodeModulesRoot()
-  if (!root) return name
+  const info = nodeModulesInfo()
+  if (!info) return name
 
   try {
-    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'))
+    const pkg = JSON.parse(readFileSync(join(info.root, 'package.json'), 'utf-8'))
     const deps = pkg.dependencies ?? {}
     const spec = deps[name]
     if (!spec || Object.keys(deps).length !== 1) return name


### PR DESCRIPTION
## Summary

- When a CLI is installed globally (`npm i -g`), MCP registration now detects that `process.argv[1]` is outside `node_modules/` and registers the bare command name (e.g. `my-cli --mcp`) instead of wrapping it in `npx` unnecessarily
- Replaces naive `command.split(' ')` in `registerAmp` with a quote-aware tokenizer so paths containing spaces (e.g. `"/path/to my/cli" --mcp`) split correctly
- Consolidates the `node_modules/` heuristic into a single `nodeModulesRoot()` helper shared by both `register()` and `detectPackageSpecifier()`

## Test plan

- [x] New test: global binary install produces `my-cli --mcp` (no runner prefix)
- [x] New test: `node_modules` install still produces `npx my-cli --mcp`
- [x] New test: quoted command paths with spaces split correctly into command + args
- [x] All 16 existing + new tests pass