### PR TITLE
fix: preserve validation messages in tty output

### DIFF
--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -935,6 +935,85 @@ describe('serve', () => {
     expect(output).toContain('Error: missing required argument <name>')
   })
 
+  test('ValidationError preserves Zod messages in machine output', async () => {
+    const cli = Cli.create('test')
+    cli.command('send', {
+      options: z.object({ address: z.string().min(32) }),
+      run() {
+        return {}
+      },
+    })
+
+    const { output, exitCode } = await serve(cli, ['send', '--address', 'abc', '--format', 'json'])
+    expect(exitCode).toBe(1)
+    expect(JSON.parse(output)).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      fieldErrors: [
+        {
+          code: 'too_small',
+          message: 'Too small: expected string to have >=32 characters',
+          missing: false,
+          path: 'address',
+        },
+      ],
+    })
+  })
+
+  test('ValidationError shows invalid option messages in TTY', async () => {
+    ;(process.stdout as any).isTTY = true
+    const cli = Cli.create('test')
+    cli.command('send', {
+      options: z.object({ address: z.string().min(32) }),
+      run() {
+        return {}
+      },
+    })
+
+    const { output, exitCode } = await serve(cli, ['send', '--address', 'abc'])
+    ;(process.stdout as any).isTTY = false
+    expect(exitCode).toBe(1)
+    expect(output).toContain(
+      'Error: invalid value for --address: Too small: expected string to have >=32 characters',
+    )
+    expect(output).not.toContain('Error: missing required argument <address>')
+  })
+
+  test('ValidationError shows invalid enum messages in TTY', async () => {
+    ;(process.stdout as any).isTTY = true
+    const cli = Cli.create('test')
+    cli.command('list', {
+      options: z.object({ state: z.enum(['open', 'closed']) }),
+      run() {
+        return {}
+      },
+    })
+
+    const { output, exitCode } = await serve(cli, ['list', '--state', 'invalid'])
+    ;(process.stdout as any).isTTY = false
+    expect(exitCode).toBe(1)
+    expect(output).toContain(
+      'Error: invalid value for --state: Invalid option: expected one of "open"|"closed"',
+    )
+  })
+
+  test('ValidationError shows positional refinement messages in TTY', async () => {
+    ;(process.stdout as any).isTTY = true
+    const cli = Cli.create('test')
+    cli.command('get', {
+      args: z.object({
+        id: z.string().refine((value) => value.startsWith('x'), { message: 'must start with x' }),
+      }),
+      run() {
+        return {}
+      },
+    })
+
+    const { output, exitCode } = await serve(cli, ['get', 'abc'])
+    ;(process.stdout as any).isTTY = false
+    expect(exitCode).toBe(1)
+    expect(output).toContain('Error: invalid value for <id>: must start with x')
+  })
+
   test('agent is true when not TTY', async () => {
     let agent: boolean | undefined
     const cli = Cli.create('test')

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -21,7 +21,7 @@ import {
   shells,
 } from './internal/command.js'
 import * as Command from './internal/command.js'
-import { isRecord, suggest } from './internal/helpers.js'
+import { isRecord, suggest, toKebab } from './internal/helpers.js'
 import { detectRunner } from './internal/pm.js'
 import type { OneOf } from './internal/types.js'
 import * as Mcp from './Mcp.js'
@@ -1864,7 +1864,7 @@ function formatHumanValidationError(
   configFlag?: string,
 ): string {
   const lines: string[] = []
-  for (const fe of error.fieldErrors) lines.push(`Error: missing required argument <${fe.path}>`)
+  for (const fe of error.fieldErrors) lines.push(formatHumanValidationLine(command, fe))
   lines.push('See below for usage.')
   lines.push('')
   lines.push(
@@ -1882,6 +1882,32 @@ function formatHumanValidationError(
     }),
   )
   return lines.join('\n')
+}
+
+/** @internal Formats a single human-readable validation issue. */
+function formatHumanValidationLine(
+  command: CommandDefinition<any, any, any>,
+  error: FieldError,
+): string {
+  const target = formatValidationTarget(command, error.path)
+  if (error.missing) return `Error: missing required argument ${target}`
+  return `Error: invalid value for ${target}: ${error.message}`
+}
+
+/** @internal Formats a field path as an option flag or positional placeholder. */
+function formatValidationTarget(
+  command: CommandDefinition<any, any, any>,
+  path: string,
+): string {
+  const [head, ...tail] = path.split('.')
+  if (!head) return 'input'
+
+  if (command.options?.shape[head]) {
+    const suffix = tail.length > 0 ? `.${tail.join('.')}` : ''
+    return `--${toKebab(head)}${suffix}`
+  }
+
+  return `<${path}>`
 }
 
 /** @internal Resolves a command from the tree by walking tokens until a leaf is found. */

--- a/src/Errors.test.ts
+++ b/src/Errors.test.ts
@@ -66,6 +66,8 @@ describe('ValidationError', () => {
       message: 'Invalid arguments',
       fieldErrors: [
         {
+          code: 'invalid_value',
+          missing: false,
           path: 'state',
           expected: 'open | closed',
           received: 'invalid',
@@ -76,6 +78,8 @@ describe('ValidationError', () => {
     expect(error.name).toBe('Incur.ValidationError')
     expect(error.fieldErrors).toEqual([
       {
+        code: 'invalid_value',
+        missing: false,
         path: 'state',
         expected: 'open | closed',
         received: 'invalid',

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -73,6 +73,10 @@ export declare namespace IncurError {
 
 /** A field-level validation error detail. */
 export type FieldError = {
+  /** The Zod issue code. */
+  code?: string | undefined
+  /** Whether the input was missing entirely. */
+  missing?: boolean | undefined
   /** The field path that failed validation. */
   path: string
   /** The expected value or type. */

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -107,6 +107,40 @@ describe('parse', () => {
     ).toThrow(expect.objectContaining({ name: 'Incur.ValidationError' }))
   })
 
+  test('captures missing metadata for missing positional args', () => {
+    try {
+      Parser.parse([], {
+        args: z.object({ name: z.string() }),
+      })
+      expect.unreachable()
+    } catch (error: any) {
+      expect(error.fieldErrors).toEqual([
+        expect.objectContaining({
+          code: 'invalid_type',
+          missing: true,
+          path: 'name',
+        }),
+      ])
+    }
+  })
+
+  test('captures metadata for invalid option values', () => {
+    try {
+      Parser.parse(['--state', 'invalid'], {
+        options: z.object({ state: z.enum(['open', 'closed']) }),
+      })
+      expect.unreachable()
+    } catch (error: any) {
+      expect(error.fieldErrors).toEqual([
+        expect.objectContaining({
+          code: 'invalid_value',
+          missing: false,
+          path: 'state',
+        }),
+      ])
+    }
+  })
+
   test('stacks boolean short aliases (-vD)', () => {
     const result = Parser.parse(['-vD'], {
       options: z.object({

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -263,6 +263,8 @@ function zodParse(schema: z.ZodObject<any>, data: Record<string, unknown>) {
   } catch (err: any) {
     const issues: any[] = err?.issues ?? err?.error?.issues ?? []
     const fieldErrors: FieldError[] = issues.map((issue: any) => ({
+      code: issue.code,
+      missing: !hasPath(data, issue.path ?? []),
       path: (issue.path ?? []).join('.'),
       expected: issue.expected ?? '',
       received: issue.received ?? '',
@@ -274,6 +276,20 @@ function zodParse(schema: z.ZodObject<any>, data: Record<string, unknown>) {
       cause: err instanceof Error ? err : undefined,
     })
   }
+}
+
+/** Checks whether the raw input contains the full issue path. */
+function hasPath(data: Record<string, unknown>, path: PropertyKey[]): boolean {
+  if (path.length === 0) return true
+
+  let current: unknown = data
+  for (const part of path) {
+    if (!isRecord(current) && !Array.isArray(current)) return false
+    if (!(part in current)) return false
+    current = (current as any)[part]
+  }
+
+  return true
 }
 
 /** Parses environment variables against a Zod schema. Falls back to `process.env` → `Deno.env` when no source is provided. */


### PR DESCRIPTION
This PR fixes misleading TTY validation output when a value is present but fails Zod validation. Previously, human-readable errors rewrote all field validation failures as missing arguments, so cases like `--address abc` with `z.string().min(32)` incorrectly rendered as `missing required argument <address>`.

The fix preserves structured Zod issue metadata in parser field errors and updates human formatting to distinguish true missing input from invalid values. Missing args still render as missing, while provided-but-invalid options and positionals now show the real validation message, such as `invalid value for --address: Too small: expected string to have >=32 characters`. Machine/JSON output remains compatible and continues to expose the underlying validation details.