### PR TITLE
feat: generate OpenAPI spec API

### DIFF
--- a/.changeset/heavy-hornets-move.md
+++ b/.changeset/heavy-hornets-move.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Added support for automatic OpenAPI v3.2.0 schema generation

--- a/README.md
+++ b/README.md
@@ -337,21 +337,6 @@ $ my-cli api createUser --name Bob
 # → name: Bob
 ```
 
-Incur can also generate an OpenAPI 3.2 document from your CLI:
-
-```ts
-import { Cli, Openapi, z } from 'incur'
-
-const cli = Cli.create('my-cli', { description: 'My CLI' }).command('users list', {
-  options: z.object({ limit: z.coerce.number().optional() }),
-  run() {
-    return { users: [] }
-  },
-})
-
-const spec = Openapi.fromCli(cli)
-```
-
 When served with `cli.fetch`, the generated spec is available at `/openapi.json`, `/openapi.yml`, `/openapi.yaml`, and `/.well-known/openapi.json`. Methods are inferred from command names: read-like commands use `GET`, update-like commands use `PATCH`, delete-like commands use `DELETE`, and other commands use `POST`.
 
 ### Serve CLIs as APIs

--- a/README.md
+++ b/README.md
@@ -337,6 +337,23 @@ $ my-cli api createUser --name Bob
 # → name: Bob
 ```
 
+Incur can also generate an OpenAPI 3.2 document from your CLI:
+
+```ts
+import { Cli, Openapi, z } from 'incur'
+
+const cli = Cli.create('my-cli', { description: 'My CLI' }).command('users list', {
+  options: z.object({ limit: z.coerce.number().optional() }),
+  run() {
+    return { users: [] }
+  },
+})
+
+const spec = Openapi.fromCli(cli)
+```
+
+When served with `cli.fetch`, the generated spec is available at `/openapi.json`, `/openapi.yml`, `/openapi.yaml`, and `/.well-known/openapi.json`. Methods are inferred from command names: read-like commands use `GET`, update-like commands use `PATCH`, delete-like commands use `DELETE`, and other commands use `POST`.
+
 ### Serve CLIs as APIs
 
 The inverse of mounting — expose your CLI as a standard Fetch API handler with `cli.fetch`. Works with Bun, Cloudflare Workers, Deno, Hono, and anything that accepts `(req: Request) => Response`.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@cfworker/json-schema": "^4.1.1",
     "@modelcontextprotocol/server": "^2.0.0-alpha.2",
+    "@scalar/openapi-types": "^0.8.0",
     "@toon-format/toon": "^2.1.0",
     "tokenx": "^1.3.0",
     "yaml": "^2.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@modelcontextprotocol/server':
         specifier: ^2.0.0-alpha.2
         version: 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
+      '@scalar/openapi-types':
+        specifier: ^0.8.0
+        version: 0.8.0
       '@toon-format/toon':
         specifier: ^2.1.0
         version: 2.1.0
@@ -829,6 +832,10 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@scalar/openapi-types@0.8.0':
+    resolution: {integrity: sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==}
+    engines: {node: '>=22'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2019,6 +2026,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@scalar/openapi-types@0.8.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { estimateTokenCount, sliceByTokens } from 'tokenx'
-import { parse as yamlParse } from 'yaml'
+import { parse as yamlParse, stringify as yamlStringify } from 'yaml'
 import { z } from 'zod'
 
 import * as Completions from './Completions.js'
@@ -276,6 +276,7 @@ export function create(
     async fetch(req: Request) {
       if (pending.length > 0) await Promise.all(pending)
       return fetchImpl(name, commands, req, {
+        description: def.description,
         envSchema: def.env,
         mcpHandler,
         middlewares,
@@ -1516,6 +1517,8 @@ async function serveImpl(
 /** @internal Options for fetchImpl. */
 declare namespace fetchImpl {
   type Options = {
+    /** CLI description. */
+    description?: string | undefined
     /** CLI-level env schema. */
     envSchema?: z.ZodObject<any> | undefined
     /** Group-level middleware collected during command resolution. */
@@ -1596,6 +1599,31 @@ function createMcpHttpHandler(name: string, version: string) {
   }
 }
 
+function isOpenapiRoute(segments: string[]) {
+  if (segments.length === 1)
+    return (
+      segments[0] === 'openapi.json' ||
+      segments[0] === 'openapi.yml' ||
+      segments[0] === 'openapi.yaml'
+    )
+  return segments[0] === '.well-known' && segments[1] === 'openapi.json' && segments.length === 2
+}
+
+function generatedOpenapi(
+  name: string,
+  commands: Map<string, CommandEntry>,
+  options: fetchImpl.Options,
+) {
+  const openapiCli = { name, description: options.description } as Cli
+  toCommands.set(openapiCli, commands)
+  if (options.rootCommand) toRootDefinition.set(openapiCli as unknown as Root, options.rootCommand)
+  return Openapi.fromCli(openapiCli, {
+    title: name,
+    ...(options.version ? { version: options.version } : undefined),
+    ...(options.description ? { description: options.description } : undefined),
+  })
+}
+
 /** @internal Handles an HTTP request by resolving a command and returning a JSON Response. */
 async function fetchImpl(
   name: string,
@@ -1607,6 +1635,19 @@ async function fetchImpl(
 
   const url = new URL(req.url)
   const segments = url.pathname.split('/').filter(Boolean)
+
+  // OpenAPI discovery: route /openapi.json, /openapi.yml, /openapi.yaml, and /.well-known/openapi.json
+  if (req.method === 'GET' && isOpenapiRoute(segments)) {
+    const spec = generatedOpenapi(name, commands, options)
+    const yaml = segments[0] === 'openapi.yml' || segments[0] === 'openapi.yaml'
+    return new Response(yaml ? yamlStringify(spec) : JSON.stringify(spec), {
+      status: 200,
+      headers: {
+        'content-type': yaml ? 'application/yaml' : 'application/json',
+        'cache-control': 'public, max-age=300',
+      },
+    })
+  }
 
   // MCP over HTTP: route /mcp to the MCP transport
   if (segments[0] === 'mcp' && segments.length === 1 && options.mcpHandler)

--- a/src/Openapi.test.ts
+++ b/src/Openapi.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
+import { parse as yamlParse } from 'yaml'
+import { z } from 'zod'
 
 vi.mock('./SyncSkills.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./SyncSkills.js')>()
@@ -31,6 +33,89 @@ function serve(cli: { serve: Cli.Cli['serve'] }, argv: string[]) {
 function json(output: string) {
   return JSON.parse(output.replace(/"duration": "[^"]+"/g, '"duration": "<stripped>"'))
 }
+
+describe('fromCli', () => {
+  test('generates OpenAPI 3.2 paths with inferred methods', () => {
+    const cli = Cli.create('api', { description: 'API', version: '1.2.3' })
+      .command('users list', {
+        description: 'List users',
+        options: z.object({ limit: z.coerce.number().optional() }),
+        output: z.object({ users: z.array(z.object({ id: z.string() })) }),
+        run() {
+          return { users: [] }
+        },
+      })
+      .command('users update', {
+        description: 'Update a user',
+        args: z.object({ id: z.string() }),
+        options: z.object({ name: z.string() }),
+        run() {
+          return { ok: true }
+        },
+      })
+      .command('users delete', {
+        args: z.object({ id: z.string() }),
+        run() {
+          return { ok: true }
+        },
+      })
+
+    const spec = Openapi.fromCli(cli)
+    expect(spec.openapi).toBe('3.2.0')
+    expect(spec.info).toEqual({ title: 'api', version: '0.0.0', description: 'API' })
+    expect(spec.paths?.['/users/list']?.get).toMatchObject({
+      operationId: 'getUsersList',
+      summary: 'List users',
+      parameters: [{ name: 'limit', in: 'query', schema: { type: 'number' } }],
+    })
+    expect(spec.paths?.['/users/update/{id}']?.patch).toMatchObject({
+      operationId: 'patchUsersUpdateId',
+      summary: 'Update a user',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['name'],
+              properties: { name: { type: 'string' } },
+            },
+          },
+        },
+      },
+    })
+    expect(spec.paths?.['/users/delete/{id}']?.delete).toMatchObject({
+      operationId: 'deleteUsersDeleteId',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+    })
+  })
+
+  test('serves generated OpenAPI schema', async () => {
+    const cli = Cli.create('api', { description: 'API' }).command('status', {
+      run() {
+        return { ok: true }
+      },
+    })
+
+    const jsonResponse = await cli.fetch(new Request('http://localhost/openapi.json'))
+    const json = await jsonResponse.json()
+    expect(json.openapi).toBe('3.2.0')
+    expect(json.paths['/status'].get.operationId).toBe('getStatus')
+
+    const wellKnownResponse = await cli.fetch(
+      new Request('http://localhost/.well-known/openapi.json'),
+    )
+    expect(await wellKnownResponse.json()).toMatchObject(json)
+
+    const ymlResponse = await cli.fetch(new Request('http://localhost/openapi.yml'))
+    expect(ymlResponse.headers.get('content-type')).toBe('application/yaml')
+    expect(yamlParse(await ymlResponse.text()).paths['/status'].get.operationId).toBe('getStatus')
+
+    const yamlResponse = await cli.fetch(new Request('http://localhost/openapi.yaml'))
+    expect(yamlParse(await yamlResponse.text()).openapi).toBe('3.2.0')
+  })
+})
 
 describe('generateCommands', () => {
   test('generates command entries from spec', async () => {

--- a/src/Openapi.ts
+++ b/src/Openapi.ts
@@ -1,10 +1,57 @@
+import type {
+  Document,
+  OperationObject,
+  ParameterObject,
+  PathItemObject,
+} from '@scalar/openapi-types/3.2'
 import { z } from 'zod'
 
+import * as Cli from './Cli.js'
 import * as Fetch from './Fetch.js'
 import { dereference } from './internal/dereference.js'
+import * as Schema from './Schema.js'
 
 /** A minimal OpenAPI 3.x spec shape. Accepts both hand-written specs and generated ones (e.g. from `@hono/zod-openapi`). */
 export type OpenAPISpec = { paths?: {} | undefined }
+
+/** Options for generating an OpenAPI document from an incur CLI. */
+export type GenerateOptions = {
+  /** API description. Defaults to the CLI description. */
+  description?: string | undefined
+  /** Server URLs to advertise in the generated document. */
+  servers?: { url: string; description?: string | undefined }[] | undefined
+  /** API title. Defaults to the CLI name. */
+  title?: string | undefined
+  /** API version. Defaults to `0.0.0`. */
+  version?: string | undefined
+}
+
+/** HTTP methods generated for commands. */
+type HttpMethod = 'delete' | 'get' | 'patch' | 'post'
+
+/** Generates an OpenAPI 3.2 document from an incur CLI's command tree. */
+export function fromCli(cli: Cli.Cli, options: GenerateOptions = {}): Document {
+  const commands = Cli.toCommands.get(cli)
+  if (!commands) throw new Error('No commands registered on this CLI instance')
+
+  const paths: NonNullable<Document['paths']> = {}
+  const root = Cli.toRootDefinition.get(cli as unknown as Cli.Root)
+  if (root) addCommand(paths, [], root)
+  for (const [name, entry] of commands) addEntry(paths, splitCommandName(name), entry)
+
+  return {
+    openapi: '3.2.0',
+    info: {
+      title: options.title ?? cli.name,
+      version: options.version ?? '0.0.0',
+      ...((options.description ?? cli.description)
+        ? { description: options.description ?? cli.description }
+        : undefined),
+    },
+    ...(options.servers ? { servers: options.servers } : undefined),
+    paths,
+  }
+}
 
 /** Internal operation shape after casting. */
 type Operation = {
@@ -38,6 +85,184 @@ type GeneratedCommand = {
   description?: string | undefined
   options?: z.ZodObject<any> | undefined
   run: (context: any) => any
+}
+
+function addEntry(paths: NonNullable<Document['paths']>, segments: string[], entry: any) {
+  if ('_alias' in entry) return
+  if ('_fetch' in entry) return
+  if ('_group' in entry) {
+    for (const [name, child] of entry.commands)
+      addEntry(paths, [...segments, ...splitCommandName(name)], child)
+    return
+  }
+  addCommand(paths, segments, entry)
+}
+
+function splitCommandName(name: string) {
+  return name.split(/\s+/).filter(Boolean)
+}
+
+function addCommand(paths: NonNullable<Document['paths']>, segments: string[], command: any) {
+  const argsSchema = command.args ? Schema.toJsonSchema(command.args) : undefined
+  const optionsSchema = command.options ? Schema.toJsonSchema(command.options) : undefined
+  const outputSchema = command.output ? Schema.toJsonSchema(command.output) : undefined
+  const args = objectProperties(argsSchema)
+  const requiredArgs = new Set(requiredProperties(argsSchema))
+  const method = inferMethod(segments)
+  const pathVariants = createPathVariants(segments, args, requiredArgs)
+
+  for (const variant of pathVariants) {
+    const parameters: ParameterObject[] = []
+    for (const name of variant.args) {
+      const schema = args[name] ?? { type: 'string' }
+      parameters.push({ name, in: 'path', required: true, schema })
+    }
+    if (method === 'get' || method === 'delete')
+      for (const [name, schema] of Object.entries(objectProperties(optionsSchema)))
+        parameters.push({
+          name,
+          in: 'query',
+          ...(requiredProperties(optionsSchema).includes(name) ? { required: true } : undefined),
+          schema,
+        })
+
+    const operation: OperationObject = {
+      operationId: operationId(segments, method, variant.args),
+      ...(command.description ? { summary: command.description } : undefined),
+      ...(parameters.length ? { parameters } : undefined),
+      ...requestBody(method, optionsSchema),
+      responses: responses(outputSchema),
+    }
+
+    const item = (paths[variant.path] ?? {}) as PathItemObject
+    ;(item as any)[method] = operation
+    paths[variant.path] = item
+  }
+}
+
+function createPathVariants(
+  segments: string[],
+  args: Record<string, Record<string, unknown>>,
+  requiredArgs: Set<string>,
+) {
+  const names = Object.keys(args)
+  const requiredCount = names.findIndex((name) => !requiredArgs.has(name))
+  const baseCount = requiredCount === -1 ? names.length : requiredCount
+  const variants: { args: string[]; path: `/${string}` }[] = []
+  for (let count = baseCount; count <= names.length; count++) {
+    const included = names.slice(0, count)
+    const suffix = included.map((name) => `{${name}}`)
+    variants.push({
+      args: included,
+      path: `/${[...segments, ...suffix].map(encodePathSegment).join('/')}`,
+    })
+  }
+  if (variants.length === 0)
+    variants.push({ args: [], path: `/${segments.map(encodePathSegment).join('/')}` })
+  return variants
+}
+
+function inferMethod(segments: string[]): HttpMethod {
+  const text = segments.map(splitCamelCase).join(' ').toLowerCase()
+  if (/\b(delete|remove|rm|destroy|clear)\b/.test(text)) return 'delete'
+  if (/\b(update|edit|modify|set|enable|disable|rename|patch)\b/.test(text)) return 'patch'
+  if (/\b(get|list|show|read|search|find|status|describe|info|health|check)\b/.test(text))
+    return 'get'
+  return 'post'
+}
+
+function splitCamelCase(value: string) {
+  return value.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+}
+
+function requestBody(method: HttpMethod, schema?: Record<string, unknown> | undefined) {
+  if (!schema || method === 'get' || method === 'delete') return {}
+  return {
+    requestBody: {
+      required: requiredProperties(schema).length > 0,
+      content: { 'application/json': { schema } },
+    },
+  }
+}
+
+function responses(schema?: Record<string, unknown> | undefined) {
+  return {
+    '200': {
+      description: 'Command completed successfully.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['ok', 'data', 'meta'],
+            properties: {
+              ok: { const: true },
+              data: schema ?? {},
+              meta: metaSchema(),
+            },
+          },
+        },
+      },
+    },
+    '400': errorResponse('Validation error.'),
+    '500': errorResponse('Command failed.'),
+  }
+}
+
+function errorResponse(description: string) {
+  return {
+    description,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          required: ['ok', 'error', 'meta'],
+          properties: {
+            ok: { const: false },
+            error: {
+              type: 'object',
+              required: ['code', 'message'],
+              properties: {
+                code: { type: 'string' },
+                message: { type: 'string' },
+                retryable: { type: 'boolean' },
+              },
+            },
+            meta: metaSchema(),
+          },
+        },
+      },
+    },
+  }
+}
+
+function metaSchema() {
+  return {
+    type: 'object',
+    required: ['command', 'duration'],
+    properties: {
+      command: { type: 'string' },
+      duration: { type: 'string' },
+    },
+  }
+}
+
+function objectProperties(schema: Record<string, unknown> | undefined) {
+  return (schema?.properties ?? {}) as Record<string, Record<string, unknown>>
+}
+
+function requiredProperties(schema: Record<string, unknown> | undefined) {
+  return (schema?.required ?? []) as string[]
+}
+
+function operationId(segments: string[], method: HttpMethod, args: string[]) {
+  const raw = [...segments, ...(args.length ? [args.join(' ')] : [])].join(' ')
+  const pascal = raw.replace(/(?:^|[\s_-]+)(\w)/g, (_, char: string) => char.toUpperCase())
+  return `${method}${pascal}`
+}
+
+function encodePathSegment(segment: string) {
+  if (segment.startsWith('{') && segment.endsWith('}')) return segment
+  return encodeURIComponent(segment)
 }
 
 /** Generates incur command entries from an OpenAPI spec. Resolves all `$ref` pointers. */

--- a/src/Skill.test.ts
+++ b/src/Skill.test.ts
@@ -375,7 +375,12 @@ describe('split', () => {
 
   test('YAML-quotes description containing colon-space', () => {
     const groups = new Map([['search', 'Search items. Use key: value for precision']])
-    const files = Skill.split('app', [{ name: 'search list', description: 'List results' }], 1, groups)
+    const files = Skill.split(
+      'app',
+      [{ name: 'search list', description: 'List results' }],
+      1,
+      groups,
+    )
     expect(files[0]!.content).toContain(
       'description: "Search items. Use key: value for precision. Run `app search --help` for usage details."',
     )

--- a/src/Skill.ts
+++ b/src/Skill.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
-import type { z } from 'zod'
 import { stringify as yamlStringify } from 'yaml'
+import type { z } from 'zod'
 
 import * as Schema from './Schema.js'
 

--- a/src/SyncSkills.ts
+++ b/src/SyncSkills.ts
@@ -163,7 +163,8 @@ export async function list(
         try {
           const content = await fs.readFile(path.resolve(cwd, match), 'utf8')
           const meta = parseFrontmatter(content)
-          const skillName = pattern === '_root' ? (meta.name ?? name) : path.basename(path.dirname(match))
+          const skillName =
+            pattern === '_root' ? (meta.name ?? name) : path.basename(path.dirname(match))
           if (!skills.some((s) => s.name === skillName)) {
             skills.push({
               name: skillName,
@@ -279,7 +280,10 @@ function collectEntries(
   return result.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''))
 }
 
-function parseFrontmatter(content: string): { description?: string | undefined; name?: string | undefined } {
+function parseFrontmatter(content: string): {
+  description?: string | undefined
+  name?: string | undefined
+} {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
   if (!match) return {}
 

--- a/src/internal/dereference.test.ts
+++ b/src/internal/dereference.test.ts
@@ -434,10 +434,7 @@ describe('dereference', () => {
         },
       },
       root: {
-        allOf: [
-          { $ref: '#/components/schemas/Name' },
-          { $ref: '#/components/schemas/Age' },
-        ],
+        allOf: [{ $ref: '#/components/schemas/Name' }, { $ref: '#/components/schemas/Age' }],
       },
     }
     const result = dereference(spec) as any

--- a/src/internal/dereference.ts
+++ b/src/internal/dereference.ts
@@ -69,7 +69,8 @@ function resolvePointer(root: unknown, pointer: string): unknown {
     if (typeof current !== 'object' || current === null)
       throw new Error(`Cannot resolve $ref "${pointer}": path segment "${part}" not found`)
     current = (current as Record<string, unknown>)[part]
-    if (current === undefined) throw new Error(`Cannot resolve $ref "${pointer}": "${part}" not found`)
+    if (current === undefined)
+      throw new Error(`Cannot resolve $ref "${pointer}": "${part}" not found`)
   }
   return current
 }


### PR DESCRIPTION
ability to generate OpenAPI v3.2.0 automatically

```ts
import { Cli, Openapi, z } from 'incur'

const cli = Cli.create('my-cli', { description: 'My CLI' }).command('users list', {
  options: z.object({ limit: z.coerce.number().optional() }),
  run() {
    return { users: [] }
  },
})

const spec = Openapi.fromCli(cli)
```

validate: in `exmaples/npm`:

```sh
bun cli.ts

curl http://localhost:3000/openapi.json
```

note: other 'unrelated' changes are from `pnpm check`

playground https://stackblitz.com/edit/unjs-h3-sgf15m6f?file=server.mjs (visit `/openapi.json` in preview)