### PR TITLE
Add generated TypeScript clients

### DIFF
--- a/.changeset/typed-client.md
+++ b/.changeset/typed-client.md
@@ -1,0 +1,5 @@
+---
+"incur": minor
+---
+
+Add typed TypeScript client generation for CLIs, backed by structured RPC command execution.

--- a/README.md
+++ b/README.md
@@ -879,6 +879,29 @@ Precedence is `argv > config > zod defaults`. Only command `options` are loaded 
 
 Use `incur gen` to auto-generate a `config.schema.json` to distribute with your CLI for consumer autocomplete.
 
+Use `incur gen --client` to also generate a typed TypeScript client module:
+
+```sh
+incur gen --entry ./src/cli.ts --client
+```
+
+The generated client calls the CLI over `POST /_incur/rpc` with structured `args` and `options`.
+Command and group names are preserved exactly as property keys. Identifier-safe names work with dot
+notation, and names with punctuation, spaces, reserved words, or other special keys use bracket
+notation:
+
+```ts
+import { Client } from 'incur'
+import { createMyCliClient } from './incur.client.js'
+
+const client = createMyCliClient({
+  transport: Client.http('https://example.com'),
+})
+
+await client.users.list({ limit: 10 })
+await client['user-profile'].get({ id: 'alice' })
+```
+
 ### Filtering output
 
 Use `--filter-output` to prune command output to specific keys. Supports dot-notation for nested keys, array slices, and comma-separated paths:

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -4201,6 +4201,173 @@ describe('fetch', () => {
     `)
   })
 
+  test('POST /_incur/rpc → executes command with structured args and options', async () => {
+    const sub = Cli.create('api')
+    sub.command('echo', {
+      args: z.object({ value: z.string() }),
+      options: z.object({ value: z.string() }),
+      run: (c) => ({ arg: c.args.value, option: c.options.value }),
+    })
+    const cli = Cli.create('test')
+    cli.command(sub)
+    const req = new Request('http://localhost/_incur/rpc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        path: ['api', 'echo'],
+        args: { value: 'from args' },
+        options: { value: 'from options' },
+      }),
+    })
+    expect(await fetchJson(cli, req)).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "arg": "from args",
+            "option": "from options",
+          },
+          "meta": {
+            "command": "api echo",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('POST /_incur/rpc with omitted or empty path → root command', async () => {
+    const cli = Cli.create('test', {
+      args: z.object({ name: z.string().default('world') }),
+      options: z.object({ excited: z.boolean().default(false) }),
+      run: (c) => ({ message: `hello ${c.args.name}${c.options.excited ? '!' : ''}` }),
+    })
+    const req = new Request('http://localhost/_incur/rpc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ args: { name: 'rpc' }, options: { excited: true } }),
+    })
+    expect(await fetchJson(cli, req)).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "message": "hello rpc!",
+          },
+          "meta": {
+            "command": "test",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+    const emptyPathReq = new Request('http://localhost/_incur/rpc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path: [], args: { name: 'root' } }),
+    })
+    const { body } = await fetchJson(cli, emptyPathReq)
+    expect(body.data).toEqual({ message: 'hello root' })
+  })
+
+  test('POST /_incur/rpc resolves exact command paths only', async () => {
+    const cli = Cli.create('test')
+    cli.command('users', {
+      args: z.object({ id: z.coerce.number() }),
+      run: (c) => ({ id: c.args.id }),
+    })
+    const req = new Request('http://localhost/_incur/rpc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path: ['users', '42'] }),
+    })
+    const { status, body } = await fetchJson(cli, req)
+    expect(status).toBe(404)
+    expect(body.error).toMatchInlineSnapshot(`
+      {
+        "code": "COMMAND_NOT_FOUND",
+        "message": "'42' is not a command for 'test users'.",
+      }
+    `)
+  })
+
+  test('POST /_incur/rpc preserves alias path names exactly', async () => {
+    const cli = Cli.create('test')
+    cli.command('login', {
+      aliases: ['sign-in'],
+      run: () => ({ ok: true }),
+    })
+
+    expect(
+      await fetchJson(
+        cli,
+        new Request('http://localhost/_incur/rpc', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ path: ['sign-in'] }),
+        }),
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "ok": true,
+          },
+          "meta": {
+            "command": "sign-in",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('POST /_incur/rpc validates structured body shape', async () => {
+    const cli = Cli.create('test')
+    cli.command('ping', { run: () => ({ ok: true }) })
+
+    const { status, body } = await fetchJson(
+      cli,
+      new Request('http://localhost/_incur/rpc', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: ['ping'], args: [] }),
+      }),
+    )
+
+    expect(status).toBe(400)
+    expect(body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: '`args` and `options` must be objects.',
+    })
+  })
+
+  test('POST /_incur/rpc rejects fetch gateways', async () => {
+    const cli = Cli.create('test')
+    cli.command('api', {
+      fetch: () => new Response(JSON.stringify({ ok: true })),
+    })
+
+    const { status, body } = await fetchJson(
+      cli,
+      new Request('http://localhost/_incur/rpc', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: ['api'] }),
+      }),
+    )
+
+    expect(status).toBe(404)
+    expect(body.error).toEqual({
+      code: 'COMMAND_NOT_FOUND',
+      message: "'api' is a fetch command, not an RPC command.",
+    })
+  })
+
   test('trailing path segments → positional args', async () => {
     const cli = Cli.create('test')
     cli.command('users', {
@@ -4311,6 +4478,53 @@ describe('fetch', () => {
         {
           "data": {
             "progress": 2,
+          },
+          "type": "chunk",
+        },
+        {
+          "meta": {
+            "command": "stream",
+          },
+          "ok": true,
+          "type": "done",
+        },
+      ]
+    `)
+  })
+
+  test('POST /_incur/rpc supports async generator streaming response', async () => {
+    const cli = Cli.create('test')
+    cli.command('stream', {
+      args: z.object({ prefix: z.string() }),
+      async *run(c) {
+        yield { value: `${c.args.prefix}-1` }
+        yield { value: `${c.args.prefix}-2` }
+      },
+    })
+    const res = await cli.fetch(
+      new Request('http://localhost/_incur/rpc', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: ['stream'], args: { prefix: 'rpc' } }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('application/x-ndjson')
+    const lines = (await res.text())
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+    expect(lines).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {
+            "value": "rpc-1",
+          },
+          "type": "chunk",
+        },
+        {
+          "data": {
+            "value": "rpc-2",
           },
           "type": "chunk",
         },

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -320,7 +320,14 @@ export function create(
   if (def.outputPolicy) toOutputPolicy.set(cli, def.outputPolicy)
   toMiddlewares.set(cli, middlewares)
   toCommands.set(cli, commands)
+  toPending.set(cli, pending)
   return cli
+}
+
+/** Waits for async CLI registration work, such as OpenAPI command generation, to finish. */
+export async function ready(cli: Cli): Promise<void> {
+  const pending = toPending.get(cli)
+  if (pending?.length) await Promise.all(pending)
 }
 
 export declare namespace create {
@@ -1523,6 +1530,7 @@ declare namespace fetchImpl {
     envSchema?: z.ZodObject<any> | undefined
     /** Group-level middleware collected during command resolution. */
     groupMiddlewares?: MiddlewareHandler[] | undefined
+    structuredArgs?: Record<string, unknown> | undefined
     mcpHandler?:
       | ((
           req: Request,
@@ -1657,6 +1665,15 @@ async function fetchImpl(
       vars: options.vars,
     })
 
+  // Generated client RPC: route POST /_incur/rpc with structured args/options.
+  if (
+    req.method === 'POST' &&
+    segments[0] === '_incur' &&
+    segments[1] === 'rpc' &&
+    segments.length === 2
+  )
+    return executeRpcCommand(name, commands, req, start, options)
+
   // .well-known/skills/ — Agent Skills Discovery (RFC)
   if (
     segments[0] === '.well-known' &&
@@ -1776,6 +1793,135 @@ async function fetchImpl(
   })
 }
 
+/** @internal Executes a generated-client RPC request. */
+async function executeRpcCommand(
+  name: string,
+  commands: Map<string, CommandEntry>,
+  req: Request,
+  start: number,
+  options: fetchImpl.Options,
+): Promise<Response> {
+  function jsonResponse(body: unknown, status: number) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return jsonResponse(
+      {
+        ok: false,
+        error: { code: 'VALIDATION_ERROR', message: 'Request body must be JSON.' },
+        meta: { command: '/_incur/rpc', duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      400,
+    )
+  }
+
+  if (!isRecord(body))
+    return jsonResponse(
+      {
+        ok: false,
+        error: { code: 'VALIDATION_ERROR', message: 'Request body must be an object.' },
+        meta: { command: '/_incur/rpc', duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      400,
+    )
+
+  const pathValue = body.path ?? []
+  if (!Array.isArray(pathValue) || pathValue.some((segment) => typeof segment !== 'string'))
+    return jsonResponse(
+      {
+        ok: false,
+        error: { code: 'VALIDATION_ERROR', message: '`path` must be an array of strings.' },
+        meta: { command: '/_incur/rpc', duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      400,
+    )
+
+  const args = body.args === undefined ? {} : body.args
+  const rpcOptions = body.options === undefined ? {} : body.options
+  if (!isRecord(args) || !isRecord(rpcOptions))
+    return jsonResponse(
+      {
+        ok: false,
+        error: { code: 'VALIDATION_ERROR', message: '`args` and `options` must be objects.' },
+        meta: { command: '/_incur/rpc', duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      400,
+    )
+
+  if (pathValue.length === 0) {
+    if (options.rootCommand)
+      return executeCommand(name, options.rootCommand, [], rpcOptions, start, {
+        ...options,
+        structuredArgs: args,
+      })
+    return jsonResponse(
+      {
+        ok: false,
+        error: { code: 'COMMAND_NOT_FOUND', message: 'No root command defined.' },
+        meta: { command: '/', duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      404,
+    )
+  }
+
+  const resolved = resolveExactCommand(commands, pathValue)
+  if ('error' in resolved) {
+    const parent = resolved.path ? `${name} ${resolved.path}` : name
+    const suggestion = suggest(resolved.error, resolved.commands.keys())
+    const didYouMean = suggestion ? ` Did you mean '${suggestion}'?` : ''
+    return jsonResponse(
+      {
+        ok: false,
+        error: {
+          code: 'COMMAND_NOT_FOUND',
+          message: `'${resolved.error}' is not a command for '${parent}'.${didYouMean}`,
+        },
+        meta: { command: resolved.error, duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      404,
+    )
+  }
+
+  if ('help' in resolved)
+    return jsonResponse(
+      {
+        ok: false,
+        error: {
+          code: 'COMMAND_NOT_FOUND',
+          message: `'${resolved.path}' is a command group. Specify a subcommand.`,
+        },
+        meta: { command: resolved.path, duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      404,
+    )
+
+  if ('fetchGateway' in resolved)
+    return jsonResponse(
+      {
+        ok: false,
+        error: {
+          code: 'COMMAND_NOT_FOUND',
+          message: `'${resolved.path}' is a fetch command, not an RPC command.`,
+        },
+        meta: { command: resolved.path, duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      404,
+    )
+
+  return executeCommand(resolved.path, resolved.command, [], rpcOptions, start, {
+    ...options,
+    groupMiddlewares: resolved.middlewares,
+    structuredArgs: args,
+  })
+}
+
 /** @internal Executes a resolved command for the fetch handler and returns a JSON Response. */
 async function executeCommand(
   path: string,
@@ -1804,10 +1950,11 @@ async function executeCommand(
     env: options.envSchema,
     format: 'json',
     formatExplicit: true,
+    inputArgs: options.structuredArgs,
     inputOptions,
     middlewares: allMiddleware,
     name: options.name ?? path,
-    parseMode: 'split',
+    parseMode: options.structuredArgs !== undefined ? 'structured' : 'split',
     path,
     vars: options.vars,
     version: options.version,
@@ -2044,6 +2191,40 @@ function resolveCommand(
     rest: remaining,
     ...(outputPolicy ? { outputPolicy } : undefined),
   }
+}
+
+/** @internal Resolves a command from exact path segments for structured RPC. */
+function resolveExactCommand(
+  commands: Map<string, CommandEntry>,
+  tokens: string[],
+):
+  | {
+      command: CommandDefinition<any, any, any>
+      middlewares: MiddlewareHandler[]
+      outputPolicy?: OutputPolicy | undefined
+      path: string
+    }
+  | {
+      fetchGateway: InternalFetchGateway
+      middlewares: MiddlewareHandler[]
+      outputPolicy?: OutputPolicy | undefined
+      path: string
+    }
+  | {
+      help: true
+      path: string
+      description?: string | undefined
+      commands: Map<string, CommandEntry>
+    }
+  | { error: string; path: string; commands: Map<string, CommandEntry> } {
+  const resolved = resolveCommand(commands, tokens)
+  if (('command' in resolved || 'fetchGateway' in resolved) && resolved.rest.length > 0)
+    return {
+      error: resolved.rest[0]!,
+      path: resolved.path,
+      commands: new Map(),
+    }
+  return resolved
 }
 
 /** @internal Options for serveImpl, extending public serve.Options with internal metadata. */
@@ -2473,6 +2654,9 @@ function resolveAlias(
 
 /** @internal Maps CLI instances to their command maps. */
 export const toCommands = new WeakMap<Cli, Map<string, CommandEntry>>()
+
+/** @internal Maps CLI instances to pending async registration work. */
+const toPending = new WeakMap<Cli, Promise<void>[]>()
 
 /** @internal Maps CLI instances to their middleware arrays. */
 const toMiddlewares = new WeakMap<Cli, MiddlewareHandler[]>()

--- a/src/Client.test-d.ts
+++ b/src/Client.test-d.ts
@@ -1,0 +1,31 @@
+import { expectTypeOf, test } from 'vitest'
+
+import * as Client from './Client.js'
+
+test('types data calls from explicit output generics', () => {
+  const context = Client.create({
+    transport: async () => ({
+      ok: true,
+      data: { id: 1 },
+      meta: { command: 'read', duration: '1ms' },
+    }),
+  })
+
+  expectTypeOf(
+    Client.call<{ id: number }>(context, ['read'], { args: { id: '1' } }),
+  ).resolves.toEqualTypeOf<{ id: number }>()
+})
+
+test('types result calls from explicit output and error generics', () => {
+  const context = Client.create({
+    transport: async () => ({
+      ok: true,
+      data: { value: 'ok' },
+      meta: { command: 'read', duration: '1ms' },
+    }),
+  })
+
+  expectTypeOf(
+    Client.result<{ value: string }, { message: string }>(context, ['read']),
+  ).resolves.toEqualTypeOf<Client.Result<{ value: string }, { message: string }>>()
+})

--- a/src/Client.test.ts
+++ b/src/Client.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test, vi } from 'vitest'
+import { z } from 'zod'
+
+import * as Cli from './Cli.js'
+import * as Client from './Client.js'
+
+const meta = { command: 'test', duration: '1ms' }
+
+describe('call', () => {
+  test('sends exact path, args, options, and request options to transport', async () => {
+    const transport = vi.fn<Client.Transport>().mockResolvedValue({ ok: true, data: 123, meta })
+    const context = Client.create({ transport })
+    const request = { headers: { authorization: 'Bearer token' } }
+
+    await expect(
+      Client.call(
+        context,
+        ['Exact Name', 'sub-command'],
+        {
+          args: { id: 1 },
+          options: { verbose: true },
+        },
+        request,
+      ),
+    ).resolves.toBe(123)
+
+    expect(transport).toHaveBeenCalledWith(
+      {
+        path: ['Exact Name', 'sub-command'],
+        args: { id: 1 },
+        options: { verbose: true },
+      },
+      request,
+    )
+  })
+
+  test('throws ClientError in data mode for failed envelopes', async () => {
+    const error = { message: 'Denied', code: 'DENIED', data: { retry: false } }
+    const context = Client.create({
+      transport: Client.local(() => ({ ok: false, error, meta })),
+    })
+
+    await expect(Client.call(context, ['secret'])).rejects.toMatchObject({
+      name: 'ClientError',
+      message: 'Denied',
+      code: 'DENIED',
+      data: { retry: false },
+      error,
+    })
+  })
+
+  test('rejects malformed transport envelopes', async () => {
+    const context = Client.create({
+      transport: Client.local(() => ({ ok: true, data: 'pong' }) as any),
+    })
+
+    await expect(Client.call(context, ['ping'])).rejects.toThrow('Malformed RPC envelope')
+  })
+})
+
+describe('result', () => {
+  test('returns failed envelopes without throwing', async () => {
+    const error = { message: 'Nope', code: 'NOPE' }
+    const context = Client.create({
+      transport: Client.local(() => ({ ok: false, error, meta })),
+    })
+
+    await expect(Client.result(context, ['fail'])).resolves.toEqual({ ok: false, error, meta })
+  })
+})
+
+describe('object', () => {
+  test('defines hazardous names as own properties on null-prototype objects', () => {
+    const client = Client.object<Record<string, unknown>>()
+    const method = () => 'ok'
+
+    Client.define(client, '__proto__', method)
+    Client.define(client, 'constructor', method)
+    Client.define(client, 'then', method)
+
+    expect(Object.getPrototypeOf(client)).toBe(null)
+    expect(client.__proto__).toBe(method)
+    expect(client.constructor).toBe(method)
+    expect(client.then).toBe(method)
+    expect(Object.keys(client)).toEqual(['__proto__', 'constructor', 'then'])
+  })
+})
+
+describe('http', () => {
+  test('integrates with Cli.fetch over /_incur/rpc', async () => {
+    const cli = Cli.create('test').command('sum', {
+      args: z.object({ left: z.number(), right: z.number() }),
+      options: z.object({ double: z.boolean().default(false) }),
+      run(c) {
+        const value = c.args.left + c.args.right
+        return { value: c.options.double ? value * 2 : value }
+      },
+    })
+    const context = Client.create({
+      transport: Client.http('http://localhost', {
+        fetch: (input, init) => cli.fetch(new Request(input, init)),
+      }),
+    })
+
+    await expect(
+      Client.call(context, ['sum'], {
+        args: { left: 2, right: 3 },
+        options: { double: true },
+      }),
+    ).resolves.toEqual({ value: 10 })
+  })
+
+  test('POSTs to /_incur/rpc with JSON body and request options', async () => {
+    const signal = AbortSignal.abort()
+    const fetch = vi.fn<Client.http.Fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, data: { created: true }, meta }), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    const transport = Client.http('https://example.com/api/', {
+      fetch,
+      headers: { authorization: 'Bearer default', 'x-default': '1' },
+    })
+
+    await expect(
+      transport(
+        { path: ['users', 'create'], args: { name: 'Ada' }, options: {} },
+        { headers: { authorization: 'Bearer call' }, signal },
+      ),
+    ).resolves.toEqual({ ok: true, data: { created: true }, meta })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, init] = fetch.mock.calls[0]!
+    expect(String(url)).toBe('https://example.com/_incur/rpc')
+    expect(init?.method).toBe('POST')
+    expect(init?.signal).toBe(signal)
+    expect(JSON.parse(init?.body as string)).toEqual({
+      path: ['users', 'create'],
+      args: { name: 'Ada' },
+      options: {},
+    })
+
+    const headers = new Headers(init?.headers)
+    expect(headers.get('authorization')).toBe('Bearer call')
+    expect(headers.get('x-default')).toBe('1')
+    expect(headers.get('content-type')).toBe('application/json')
+    expect(headers.get('accept')).toBe('application/json')
+  })
+
+  test('throws ClientError for non-JSON responses', async () => {
+    await expect(
+      Client.http('https://example.com', {
+        fetch: async () => new Response('plain text', { status: 200 }),
+      })({ path: ['ping'], args: {}, options: {} }),
+    ).rejects.toMatchObject({
+      name: 'ClientError',
+      message: 'Expected a JSON RPC envelope',
+      status: 200,
+      data: 'plain text',
+    })
+  })
+
+  test('returns HTTP error envelopes so result clients can avoid throwing', async () => {
+    const envelope = {
+      ok: false,
+      error: { message: 'Bad request' },
+      meta: { command: 'ping', duration: '1ms' },
+    }
+
+    await expect(
+      Client.http('https://example.com', {
+        fetch: async () => new Response(JSON.stringify(envelope), { status: 400 }),
+      })({ path: ['ping'], args: {}, options: {} }),
+    ).resolves.toEqual(envelope)
+  })
+})
+
+describe('parseEnvelopeResponse', () => {
+  test('requires ok true envelopes to contain data', async () => {
+    await expect(
+      Client.parseEnvelopeResponse(new Response(JSON.stringify({ ok: true, meta }))),
+    ).rejects.toThrow('Malformed RPC envelope')
+  })
+
+  test('requires ok false envelopes to contain an error message', async () => {
+    await expect(
+      Client.parseEnvelopeResponse(new Response(JSON.stringify({ ok: false, error: {}, meta }))),
+    ).rejects.toThrow('Malformed RPC envelope')
+  })
+})

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,0 +1,302 @@
+/** Per-call options for generated client methods. */
+export type RequestOptions = {
+  /** Headers merged into the transport request. */
+  headers?: HeadersInit | undefined
+  /** Abort signal passed to the transport request. */
+  signal?: AbortSignal | undefined
+}
+
+/** Metadata included in every incur RPC envelope. */
+export type Meta = {
+  /** Resolved command path. */
+  command: string
+  /** Command execution duration formatted by incur. */
+  duration: string
+  /** Optional call-to-action payload emitted by the command. */
+  cta?: unknown | undefined
+}
+
+/** Error payload included in failed incur RPC envelopes. */
+export type RpcError = {
+  /** Stable error code. */
+  code?: string | number | undefined
+  /** Human-readable error message. */
+  message: string
+  /** Whether the command error is retryable. */
+  retryable?: boolean | undefined
+  /** Structured validation errors when available. */
+  fieldErrors?: unknown | undefined
+  /** Additional error data. */
+  data?: unknown | undefined
+}
+
+/** Successful incur RPC envelope. */
+export type Success<data = unknown> = {
+  /** Success discriminator. */
+  ok: true
+  /** Command output. */
+  data: data
+  /** Envelope metadata. */
+  meta: Meta
+}
+
+/** Failed incur RPC envelope. */
+export type Failure<error extends RpcError = RpcError> = {
+  /** Failure discriminator. */
+  ok: false
+  /** Command error payload. */
+  error: error
+  /** Envelope metadata. */
+  meta: Meta
+}
+
+/** Full incur RPC result envelope. */
+export type Result<data = unknown, error extends RpcError = RpcError> =
+  | Success<data>
+  | Failure<error>
+
+/** Alias for an incur RPC result envelope. */
+export type Envelope<data = unknown, error extends RpcError = RpcError> = Result<data, error>
+
+/** Structured RPC request body sent by generated clients. */
+export type RpcRequest = {
+  /** Exact command path segments. */
+  path: string[]
+  /** Structured positional arguments. */
+  args: Record<string, unknown>
+  /** Structured command options. */
+  options: Record<string, unknown>
+}
+
+/** Transport used by generated clients. */
+export type Transport = (
+  request: RpcRequest,
+  options?: RequestOptions | undefined,
+) => Envelope | Promise<Envelope>
+
+/** Runtime context shared by generated client methods. */
+export type Context = {
+  /** Transport used for each generated method call. */
+  transport: Transport
+}
+
+/** Error thrown by data-mode generated client methods. */
+export class ClientError<error = unknown> extends Error {
+  /** Error class name. */
+  override name = 'ClientError'
+  /** Error code from the incur envelope or transport. */
+  code: string | number | undefined
+  /** Additional error data or malformed response payload. */
+  data: unknown
+  /** Original error payload. */
+  error: error | undefined
+  /** HTTP status for transport-level errors. */
+  status: number | undefined
+
+  constructor(message: string, options: ClientError.Options<error> = {}) {
+    super(message)
+    this.code = options.code
+    this.data = options.data
+    this.error = options.error
+    this.status = options.status
+  }
+}
+
+export declare namespace ClientError {
+  /** Options for constructing a client error. */
+  export type Options<error = unknown> = {
+    /** Error code from the incur envelope or transport. */
+    code?: string | number | undefined
+    /** Additional error data or malformed response payload. */
+    data?: unknown | undefined
+    /** Original error payload. */
+    error?: error | undefined
+    /** HTTP status for transport-level errors. */
+    status?: number | undefined
+  }
+}
+
+/** Creates a generated-client runtime context. */
+export function create(options: create.Options): Context {
+  return { transport: options.transport }
+}
+
+export declare namespace create {
+  /** Options for creating a generated-client runtime context. */
+  export type Options = {
+    /** Transport used for each generated method call. */
+    transport: Transport
+  }
+}
+
+/** Calls an incur command and returns its unwrapped data, throwing on command errors. */
+export async function call<data = unknown, error extends RpcError = RpcError>(
+  context: Context,
+  path: string[],
+  input: call.Input = {},
+  options: RequestOptions = {},
+): Promise<data> {
+  const result = await envelope<data, error>(context, path, input, options)
+  if (result.ok) return result.data
+  throw new ClientError(result.error.message, {
+    code: result.error.code,
+    data: result.error.data,
+    error: result.error,
+  })
+}
+
+export declare namespace call {
+  /** Structured method input passed by generated clients. */
+  export type Input = {
+    /** Structured positional arguments. */
+    args?: Record<string, unknown> | undefined
+    /** Structured command options. */
+    options?: Record<string, unknown> | undefined
+  }
+}
+
+/** Calls an incur command and returns the full result envelope. */
+export async function result<data = unknown, error extends RpcError = RpcError>(
+  context: Context,
+  path: string[],
+  input: call.Input = {},
+  options: RequestOptions = {},
+): Promise<Result<data, error>> {
+  return envelope(context, path, input, options)
+}
+
+/** Creates a null-prototype object for generated exact-key client trees. */
+export function object<objectType extends object>(): objectType {
+  return Object.create(null) as objectType
+}
+
+/** Defines an enumerable own property on a generated exact-key client tree. */
+export function define(object: object, key: string, value: unknown): void {
+  Object.defineProperty(object, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  })
+}
+
+/** Returns a custom transport unchanged. */
+export function custom(transport: Transport): Transport {
+  return transport
+}
+
+/** Returns an in-process transport unchanged. */
+export function local(transport: Transport): Transport {
+  return transport
+}
+
+/** Creates an HTTP transport for generated clients. */
+export function http(baseUrl: string | URL, options: http.Options = {}): Transport {
+  const fetch = options.fetch ?? globalThis.fetch
+  if (!fetch) throw new Error('Client.http requires a fetch implementation')
+
+  return async (request, requestOptions = {}) => {
+    const url = new URL('/_incur/rpc', baseUrl)
+    const headers = mergeHeaders(options.headers, requestOptions.headers)
+    headers.set('accept', 'application/json')
+    headers.set('content-type', 'application/json')
+
+    const init: RequestInit = {
+      body: JSON.stringify(request),
+      headers,
+      method: 'POST',
+    }
+    if (requestOptions.signal) init.signal = requestOptions.signal
+
+    const response = await fetch(url, init)
+    return parseEnvelopeResponse(response)
+  }
+}
+
+export declare namespace http {
+  /** Fetch implementation used by the HTTP transport. */
+  export type Fetch = (
+    input: RequestInfo | URL,
+    init?: RequestInit | undefined,
+  ) => Promise<Response>
+
+  /** Options for the HTTP transport. */
+  export type Options = {
+    /** Fetch implementation. Defaults to `globalThis.fetch`. */
+    fetch?: Fetch | undefined
+    /** Default headers sent with every request. */
+    headers?: HeadersInit | undefined
+  }
+}
+
+/** Parses an HTTP response as an incur RPC envelope. */
+export async function parseEnvelopeResponse(response: Response): Promise<Envelope> {
+  if (response.headers.get('content-type')?.startsWith('application/x-ndjson'))
+    throw new ClientError('Streaming RPC responses are not supported by this client', {
+      status: response.status,
+    })
+
+  const text = await response.text()
+  let value: unknown
+  try {
+    value = JSON.parse(text)
+  } catch {
+    throw new ClientError('Expected a JSON RPC envelope', { data: text, status: response.status })
+  }
+
+  assertEnvelope(value, response.status)
+  return value
+}
+
+/** Asserts that a value is an incur RPC envelope. */
+export function assertEnvelope(
+  value: unknown,
+  status?: number | undefined,
+): asserts value is Envelope {
+  if (!isObject(value)) throw malformedEnvelope(status, value)
+  if (typeof value.ok !== 'boolean') throw malformedEnvelope(status, value)
+  if (!isObject(value.meta)) throw malformedEnvelope(status, value)
+  if (typeof value.meta.command !== 'string') throw malformedEnvelope(status, value)
+  if (typeof value.meta.duration !== 'string') throw malformedEnvelope(status, value)
+
+  if (value.ok) {
+    if (!('data' in value)) throw malformedEnvelope(status, value)
+    return
+  }
+
+  if (!isObject(value.error) || typeof value.error.message !== 'string')
+    throw malformedEnvelope(status, value)
+}
+
+async function envelope<data = unknown, error extends RpcError = RpcError>(
+  context: Context,
+  path: string[],
+  input: call.Input,
+  options: RequestOptions,
+): Promise<Envelope<data, error>> {
+  const result = await context.transport(
+    {
+      args: input.args ?? {},
+      options: input.options ?? {},
+      path,
+    },
+    options,
+  )
+  assertEnvelope(result)
+  return result as Envelope<data, error>
+}
+
+function malformedEnvelope(status: number | undefined, data: unknown): ClientError {
+  return new ClientError('Malformed RPC envelope', { data, status })
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function mergeHeaders(base: HeadersInit | undefined, override: HeadersInit | undefined): Headers {
+  const headers = new Headers(base)
+  if (!override) return headers
+  new Headers(override).forEach((value, key) => headers.set(key, value))
+  return headers
+}

--- a/src/Clientgen.test.ts
+++ b/src/Clientgen.test.ts
@@ -1,0 +1,159 @@
+import { Cli, Clientgen, z } from 'incur'
+import fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import ts from 'typescript'
+
+describe('fromCli', () => {
+  test('generates nested clients with exact quoted segment keys', () => {
+    const cli = Cli.create('my-cli')
+    const project = Cli.create('project').command('deploy-create', {
+      args: z.object({ 'project-id': z.string() }),
+      options: z.object({ dryRun: z.boolean().optional() }),
+      output: z.object({ deployId: z.string(), status: z.enum(['queued', 'done']) }),
+      run: () => ({ deployId: 'd1', status: 'queued' as const }),
+    })
+    cli.command(project)
+
+    expect(Clientgen.fromCli(cli)).toMatchInlineSnapshot(`
+      "import { Client } from 'incur'
+
+      export type MyCliClient = { "project": { "deploy-create": (args: { "project-id": string }, options?: { "dryRun"?: boolean | undefined } | undefined, request?: Client.RequestOptions | undefined) => Promise<{ "deployId": string; "status": "queued" | "done" }> } }
+
+      export type MyCliResultClient = { "project": { "deploy-create": (args: { "project-id": string }, options?: { "dryRun"?: boolean | undefined } | undefined, request?: Client.RequestOptions | undefined) => Promise<Client.Result<{ "deployId": string; "status": "queued" | "done" }>> } }
+
+      export function createMyCliClient(options: Client.create.Options): MyCliClient {
+        const context = Client.create(options)
+        const client = Client.object<MyCliClient>()
+        const client_0 = Client.object<MyCliClient["project"]>()
+        Client.define(client_0, "deploy-create", ((args, options, request) => Client.call(context, ["project","deploy-create"], { args, options }, request)) as MyCliClient["project"]["deploy-create"])
+        Client.define(client, "project", client_0)
+        return client
+      }
+
+      export function createMyCliResultClient(options: Client.create.Options): MyCliResultClient {
+        const context = Client.create(options)
+        const client = Client.object<MyCliResultClient>()
+        const client_0 = Client.object<MyCliResultClient["project"]>()
+        Client.define(client_0, "deploy-create", ((args, options, request) => Client.result(context, ["project","deploy-create"], { args, options }, request)) as MyCliResultClient["project"]["deploy-create"])
+        Client.define(client, "project", client_0)
+        return client
+      }
+      "
+    `)
+  })
+
+  test('preserves command aliases as exact sibling keys', () => {
+    const cli = Cli.create('test').command('login', {
+      aliases: ['sign-in'],
+      output: z.object({ ok: z.boolean() }),
+      run: () => ({ ok: true }),
+    })
+
+    const output = Clientgen.fromCli(cli)
+    expect(output).toContain('Client.define(client, "login"')
+    expect(output).toContain('Client.define(client, "sign-in"')
+    expect(output).not.toContain('$call')
+  })
+
+  test('generates signatures for args, options, args plus options, and no inputs', () => {
+    const cli = Cli.create('test')
+      .command('args', {
+        args: z.object({ id: z.string() }),
+        run: () => ({}),
+      })
+      .command('options', {
+        options: z.object({ limit: z.number() }),
+        run: () => ({}),
+      })
+      .command('both', {
+        args: z.object({ id: z.string() }),
+        options: z.object({ limit: z.number() }),
+        run: () => ({}),
+      })
+      .command('none', { run: () => ({}) })
+
+    const output = Clientgen.fromCli(cli)
+    expect(output).toContain(
+      '"args": (args: { "id": string }, request?: Client.RequestOptions | undefined) => Promise<unknown>',
+    )
+    expect(output).toContain(
+      '"options": (options: { "limit": number }, request?: Client.RequestOptions | undefined) => Promise<unknown>',
+    )
+    expect(output).toContain(
+      '"both": (args: { "id": string }, options: { "limit": number }, request?: Client.RequestOptions | undefined) => Promise<unknown>',
+    )
+    expect(output).toContain(
+      '"none": (request?: Client.RequestOptions | undefined) => Promise<unknown>',
+    )
+  })
+
+  test('uses define calls so hazardous names stay exact properties', () => {
+    const cli = Cli.create('test')
+      .command('__proto__', { run: () => 'proto' })
+      .command('constructor', { run: () => 'constructor' })
+      .command('then', { run: () => 'then' })
+
+    const output = Clientgen.fromCli(cli)
+    expect(output).toContain('Client.object<TestClient>()')
+    expect(output).toContain('Client.define(client, "__proto__"')
+    expect(output).toContain('Client.define(client, "constructor"')
+    expect(output).toContain('Client.define(client, "then"')
+  })
+
+  test('generates separate root clients without making the main client callable', () => {
+    const cli = Cli.create('test', {
+      options: z.object({ verbose: z.boolean().optional() }),
+      output: z.object({ ok: z.boolean() }),
+      run: () => ({ ok: true }),
+    }) as Cli.Cli
+    cli.command('status', {
+      output: z.object({ ok: z.boolean() }),
+      run: () => ({ ok: true }),
+    })
+
+    const output = Clientgen.fromCli(cli)
+    expect(output).toContain('export type TestRootClient =')
+    expect(output).toContain('export function createTestRootClient')
+    expect(output).toContain('Client.call(context, [], { options }, request)')
+    expect(output).toContain('export type TestClient = { "status":')
+  })
+
+  test('generated clients typecheck under strict TypeScript', async () => {
+    const cli = Cli.create('my-cli')
+    cli.command('__proto__', {
+      output: z.object({ ok: z.boolean() }),
+      run: () => ({ ok: true }),
+    })
+    cli.command('users', {
+      options: z.object({ limit: z.number().optional() }),
+      output: z.object({ users: z.array(z.string()) }),
+      run: () => ({ users: [] }),
+    })
+
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'incur-clientgen-'))
+    try {
+      const file = path.join(dir, 'incur.client.ts')
+      await fs.writeFile(file, Clientgen.fromCli(cli))
+
+      const program = ts.createProgram([file], {
+        baseUrl: process.cwd(),
+        module: ts.ModuleKind.NodeNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        noEmit: true,
+        paths: { incur: ['src/index.ts'] },
+        skipLibCheck: true,
+        strict: true,
+        target: ts.ScriptTarget.ESNext,
+        types: ['node'],
+      })
+      const diagnostics = ts
+        .getPreEmitDiagnostics(program)
+        .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+
+      expect(diagnostics).toEqual([])
+    } finally {
+      await fs.rm(dir, { force: true, recursive: true })
+    }
+  })
+})

--- a/src/Clientgen.ts
+++ b/src/Clientgen.ts
@@ -1,0 +1,217 @@
+import fs from 'node:fs/promises'
+import { z } from 'zod'
+
+import * as Cli from './Cli.js'
+import {
+  objectSchemaToType,
+  propertyKey,
+  schemaHasProperties,
+  schemaHasRequiredProperties,
+  schemaToType,
+} from './internal/ts.js'
+import { importCli } from './internal/utils.js'
+
+/** Imports a CLI from `input`, generates an incur client module, and writes it to `output`. */
+export async function generate(input: string, output: string): Promise<void> {
+  const cli = await importCli(input)
+  await Cli.ready(cli)
+  await fs.writeFile(output, fromCli(cli))
+}
+
+/** Generates a typed client module for a CLI. */
+export function fromCli(cli: Cli.Cli): string {
+  const commands = Cli.toCommands.get(cli)
+  if (!commands) throw new Error('No commands registered on this CLI instance')
+
+  const name = pascalCase(cli.name)
+  const entries = collectEntries(commands, [])
+  const root = Cli.toRootDefinition.get(cli as unknown as Cli.Root)
+  const tree = buildTree(entries)
+  const clientTypeName = `${name}Client`
+  const resultClientTypeName = `${name}ResultClient`
+  const lines = ["import { Client } from 'incur'", '']
+
+  lines.push(`export type ${clientTypeName} = ${renderType(tree, 'data')}`, '')
+  lines.push(`export type ${resultClientTypeName} = ${renderType(tree, 'result')}`, '')
+
+  if (root) {
+    const rootEntry = commandEntry([], root)
+    lines.push(`export type ${name}RootClient = ${methodType(rootEntry, 'data')}`, '')
+    lines.push(`export type ${name}RootResultClient = ${methodType(rootEntry, 'result')}`, '')
+  }
+
+  lines.push(
+    `export function create${name}Client(options: Client.create.Options): ${clientTypeName} {`,
+    '  const context = Client.create(options)',
+    ...renderCreateObject('client', tree, clientTypeName, 'data', [], '  '),
+    '  return client',
+    '}',
+    '',
+    `export function create${name}ResultClient(options: Client.create.Options): ${resultClientTypeName} {`,
+    '  const context = Client.create(options)',
+    ...renderCreateObject('client', tree, resultClientTypeName, 'result', [], '  '),
+    '  return client',
+    '}',
+  )
+
+  if (root) {
+    const rootEntry = commandEntry([], root)
+    lines.push(
+      '',
+      `export function create${name}RootClient(options: Client.create.Options): ${name}RootClient {`,
+      '  const context = Client.create(options)',
+      `  return (${renderMethod(rootEntry, [], 'data')}) as ${name}RootClient`,
+      '}',
+      '',
+      `export function create${name}RootResultClient(options: Client.create.Options): ${name}RootResultClient {`,
+      '  const context = Client.create(options)',
+      `  return (${renderMethod(rootEntry, [], 'result')}) as ${name}RootResultClient`,
+      '}',
+    )
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+type Entry = {
+  args?: z.ZodObject<any> | undefined
+  options?: z.ZodObject<any> | undefined
+  output?: z.ZodType | undefined
+  path: string[]
+}
+
+type Node = {
+  children: Map<string, Node>
+  entry?: Entry | undefined
+}
+
+function collectEntries(commands: Map<string, any>, prefix: string[]): Entry[] {
+  const result: Entry[] = []
+  for (const [name, rawEntry] of commands) {
+    const entry = '_alias' in rawEntry && rawEntry._alias ? commands.get(rawEntry.target) : rawEntry
+    if (!entry) continue
+    const path = [...prefix, name]
+
+    if ('_group' in entry && entry._group) {
+      result.push(...collectEntries(entry.commands, path))
+      continue
+    }
+
+    if ('_fetch' in entry && entry._fetch) continue
+    result.push(commandEntry(path, entry))
+  }
+  return result.sort((a, b) => a.path.join('\u0000').localeCompare(b.path.join('\u0000')))
+}
+
+function commandEntry(path: string[], command: any): Entry {
+  return {
+    path,
+    args: command.args,
+    options: command.options,
+    output: command.output,
+  }
+}
+
+function buildTree(entries: Entry[]): Node {
+  const root: Node = { children: new Map() }
+  for (const entry of entries) {
+    let node = root
+    for (const segment of entry.path) {
+      let child = node.children.get(segment)
+      if (!child) {
+        child = { children: new Map() }
+        node.children.set(segment, child)
+      }
+      node = child
+    }
+    node.entry = entry
+  }
+  return root
+}
+
+function renderType(node: Node, mode: 'data' | 'result'): string {
+  const fields: string[] = []
+  for (const [key, child] of node.children) {
+    const type = child.entry ? methodType(child.entry, mode) : renderType(child, mode)
+    fields.push(`${propertyKey(key)}: ${type}`)
+  }
+  return fields.length === 0 ? '{}' : `{ ${fields.join('; ')} }`
+}
+
+function methodType(entry: Entry, mode: 'data' | 'result'): string {
+  const args = schemaHasProperties(entry.args) ? objectSchemaToType(entry.args) : undefined
+  const options = schemaHasProperties(entry.options) ? objectSchemaToType(entry.options) : undefined
+  const output = entry.output ? schemaToType(entry.output) : 'unknown'
+  const result = mode === 'data' ? output : `Client.Result<${output}>`
+  const request = 'request?: Client.RequestOptions | undefined'
+
+  if (args && options) {
+    const optionsParam = schemaHasRequiredProperties(entry.options)
+      ? `options: ${options}`
+      : `options?: ${options} | undefined`
+    return `(args: ${args}, ${optionsParam}, ${request}) => Promise<${result}>`
+  }
+  if (args) return `(args: ${args}, ${request}) => Promise<${result}>`
+  if (options) {
+    const optionsParam = schemaHasRequiredProperties(entry.options)
+      ? `options: ${options}`
+      : `options?: ${options} | undefined`
+    return `(${optionsParam}, ${request}) => Promise<${result}>`
+  }
+  return `(${request}) => Promise<${result}>`
+}
+
+function renderCreateObject(
+  name: string,
+  node: Node,
+  typeName: string,
+  mode: 'data' | 'result',
+  path: string[],
+  prefix: string,
+): string[] {
+  const lines = [`${prefix}const ${name} = Client.object<${typeName}>()`]
+  let index = 0
+  for (const [key, child] of node.children) {
+    const nextPath = [...path, key]
+    if (child.entry) {
+      lines.push(
+        `${prefix}Client.define(${name}, ${propertyKey(key)}, (${renderMethod(child.entry, child.entry.path, mode)}) as ${propertyAccess(typeName, [key])})`,
+      )
+      continue
+    }
+
+    const childName = nextName(name, index++)
+    const childType = propertyAccess(typeName, nextPath)
+    lines.push(...renderCreateObject(childName, child, childType, mode, nextPath, prefix))
+    lines.push(`${prefix}Client.define(${name}, ${propertyKey(key)}, ${childName})`)
+  }
+  return lines
+}
+
+function renderMethod(entry: Entry, path: string[], mode: 'data' | 'result'): string {
+  const helper = mode === 'data' ? 'call' : 'result'
+  const args = schemaHasProperties(entry.args)
+  const options = schemaHasProperties(entry.options)
+  const call = (input: string, request: string) =>
+    `Client.${helper}(context, ${JSON.stringify(path)}, ${input}, ${request})`
+
+  if (args && options) return `(args, options, request) => ${call('{ args, options }', 'request')}`
+  if (args) return `(args, request) => ${call('{ args }', 'request')}`
+  if (options) return `(options, request) => ${call('{ options }', 'request')}`
+  return `(request) => ${call('{}', 'request')}`
+}
+
+function propertyAccess(typeName: string, path: string[]): string {
+  return path.reduce((type, key) => `${type}[${propertyKey(key)}]`, typeName)
+}
+
+function nextName(name: string, index: number): string {
+  return `${name}_${index}`
+}
+
+function pascalCase(value: string): string {
+  const parts = value.match(/[A-Za-z0-9]+/g) ?? ['Client']
+  const result = parts.map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`).join('')
+  return /^\d/.test(result) ? `_${result}` : result
+}

--- a/src/Openapi.test.ts
+++ b/src/Openapi.test.ts
@@ -118,6 +118,8 @@ describe('fromCli', () => {
 })
 
 describe('generateCommands', () => {
+  const fetch = () => new Response('{}')
+
   test('generates command entries from spec', async () => {
     const commands = await Openapi.generateCommands(spec, app.fetch)
     expect(commands.has('listUsers')).toBe(true)
@@ -138,6 +140,138 @@ describe('generateCommands', () => {
     const cmd = commands.get('listUsers')!
     const limitSchema = cmd.options!.shape.limit
     expect(limitSchema.description).toBe('Max results')
+  })
+
+  test('attaches output from 200 JSON response schema', async () => {
+    const commands = await Openapi.generateCommands(
+      {
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'listUsers',
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        required: ['users'],
+                        properties: { users: { type: 'array', items: { type: 'string' } } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      fetch,
+    )
+
+    const output = commands.get('listUsers')!.output
+    expect(output).toBeDefined()
+    expect(output!.safeParse({ users: ['Alice'] }).success).toBe(true)
+    expect(output!.safeParse({ users: [1] }).success).toBe(false)
+  })
+
+  test('prefers 200 over other 2xx JSON response schemas', async () => {
+    const commands = await Openapi.generateCommands(
+      {
+        paths: {
+          '/choice': {
+            get: {
+              operationId: 'choice',
+              responses: {
+                '201': {
+                  description: 'Created',
+                  content: { 'application/json': { schema: { type: 'number' } } },
+                },
+                '200': {
+                  description: 'OK',
+                  content: { 'application/json': { schema: { type: 'string' } } },
+                },
+              },
+            },
+          },
+        },
+      },
+      fetch,
+    )
+
+    const output = commands.get('choice')!.output!
+    expect(output.safeParse('ok').success).toBe(true)
+    expect(output.safeParse(1).success).toBe(false)
+  })
+
+  test('falls back to first 2xx JSON response schema', async () => {
+    const commands = await Openapi.generateCommands(
+      {
+        paths: {
+          '/users': {
+            post: {
+              operationId: 'createUser',
+              responses: {
+                '201': {
+                  description: 'Created',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        required: ['created'],
+                        properties: { created: { type: 'boolean' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      fetch,
+    )
+
+    const output = commands.get('createUser')!.output
+    expect(output).toBeDefined()
+    expect(output!.safeParse({ created: true }).success).toBe(true)
+    expect(output!.safeParse({ created: 'yes' }).success).toBe(false)
+  })
+
+  test('uses default response only when it has a JSON schema', async () => {
+    const commands = await Openapi.generateCommands(
+      {
+        paths: {
+          '/fallback': {
+            get: {
+              operationId: 'fallback',
+              responses: {
+                default: {
+                  description: 'Default',
+                  content: { 'application/json': { schema: { type: 'boolean' } } },
+                },
+              },
+            },
+          },
+          '/download': {
+            get: {
+              operationId: 'download',
+              responses: {
+                default: {
+                  description: 'Default',
+                  content: { 'text/plain': { schema: { type: 'string' } } },
+                },
+              },
+            },
+          },
+        },
+      },
+      fetch,
+    )
+
+    expect(commands.get('fallback')!.output!.safeParse(true).success).toBe(true)
+    expect(commands.get('download')!.output).toBeUndefined()
   })
 })
 
@@ -395,6 +529,23 @@ describe('@hono/zod-openapi integration', () => {
       'json',
     ])
     expect(json(output).limit).toBe(3)
+  })
+
+  test('generated commands include output schemas from zod-openapi responses', async () => {
+    const commands = await Openapi.generateCommands(openapiSpec, openapiApp.fetch)
+
+    const listUsers = commands.get('listUsers')!.output
+    expect(listUsers).toBeDefined()
+    expect(listUsers!.safeParse({ users: [{ id: 1, name: 'Alice' }], limit: 10 }).success).toBe(
+      true,
+    )
+    expect(listUsers!.safeParse({ users: [{ id: '1', name: 'Alice' }], limit: 10 }).success).toBe(
+      false,
+    )
+
+    const createUser = commands.get('createUser')!.output
+    expect(createUser).toBeDefined()
+    expect(createUser!.safeParse({ created: true, name: 'Bob' }).success).toBe(true)
   })
 })
 

--- a/src/Openapi.ts
+++ b/src/Openapi.ts
@@ -59,7 +59,7 @@ type Operation = {
   operationId?: string | undefined
   parameters?: readonly Parameter[] | undefined
   requestBody?: RequestBody | undefined
-  responses?: Record<string, unknown> | undefined
+  responses?: Record<string, ResponseObject> | undefined
   summary?: string | undefined
 }
 
@@ -76,6 +76,10 @@ type RequestBody = {
   required?: boolean | undefined
 }
 
+type ResponseObject = {
+  content?: Record<string, { schema?: unknown }> | undefined
+}
+
 /** A fetch handler. */
 type FetchHandler = (req: Request) => Response | Promise<Response>
 
@@ -84,6 +88,7 @@ type GeneratedCommand = {
   args?: z.ZodObject<any> | undefined
   description?: string | undefined
   options?: z.ZodObject<any> | undefined
+  output?: z.ZodType | undefined
   run: (context: any) => any
 }
 
@@ -316,11 +321,13 @@ export async function generateCommands(
         optShape[key] = zodType
       }
       const optionsSchema = Object.keys(optShape).length > 0 ? z.object(optShape) : undefined
+      const outputSchema = responseOutputSchema(op.responses)
 
       commands.set(name, {
         description: op.summary ?? op.description,
         args: argsSchema,
         options: optionsSchema,
+        ...(outputSchema ? { output: outputSchema } : undefined),
         run: createHandler({
           basePath: options.basePath,
           fetch,
@@ -335,6 +342,51 @@ export async function generateCommands(
   }
 
   return commands
+}
+
+function responseOutputSchema(responses: Operation['responses']) {
+  const schema = responseJsonSchema(responses)
+  if (!isJsonSchemaObject(schema)) return undefined
+  try {
+    return toZod(schema)
+  } catch {
+    return undefined
+  }
+}
+
+function responseJsonSchema(responses: Operation['responses']) {
+  if (!responses) return undefined
+
+  const ok200 = jsonContentSchema(responses['200'])
+  if (ok200 !== undefined) return ok200
+
+  for (const [status, response] of Object.entries(responses)) {
+    if (/^2\d\d$/.test(status)) {
+      const schema = jsonContentSchema(response)
+      if (schema !== undefined) return schema
+    }
+  }
+
+  return jsonContentSchema(responses.default)
+}
+
+function jsonContentSchema(response: ResponseObject | undefined) {
+  const content = response?.content
+  if (!content) return undefined
+
+  const exact = content['application/json']?.schema
+  if (exact !== undefined) return exact
+
+  for (const [mediaType, media] of Object.entries(content)) {
+    const type = mediaType.toLowerCase().split(';', 1)[0]?.trim()
+    if (type === 'application/json' || type?.endsWith('+json')) return media.schema
+  }
+
+  return undefined
+}
+
+function isJsonSchemaObject(schema: unknown): schema is Record<string, unknown> {
+  return typeof schema === 'object' && schema !== null && !Array.isArray(schema)
 }
 
 function createHandler(config: {

--- a/src/Typegen.test.ts
+++ b/src/Typegen.test.ts
@@ -16,8 +16,8 @@ describe('fromCli', () => {
       "declare module 'incur' {
         interface Register {
           commands: {
-            'get': { args: { id: number }; options: {} }
-            'list': { args: {}; options: { limit: number } }
+            "get": { args: { "id": number }; options: {} }
+            "list": { args: {}; options: { "limit": number } }
           }
         }
       }
@@ -32,7 +32,7 @@ describe('fromCli', () => {
       "declare module 'incur' {
         interface Register {
           commands: {
-            'ping': { args: {}; options: {} }
+            "ping": { args: {}; options: {} }
           }
         }
       }
@@ -57,8 +57,8 @@ describe('fromCli', () => {
       "declare module 'incur' {
         interface Register {
           commands: {
-            'pr create': { args: { title: string }; options: {} }
-            'pr list': { args: {}; options: { state: string } }
+            "pr create": { args: { "title": string }; options: {} }
+            "pr list": { args: {}; options: { "state": string } }
           }
         }
       }
@@ -80,7 +80,7 @@ describe('fromCli', () => {
       "declare module 'incur' {
         interface Register {
           commands: {
-            'pr review approve': { args: { id: number }; options: {} }
+            "pr review approve": { args: { "id": number }; options: {} }
           }
         }
       }
@@ -105,7 +105,7 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain('verbose: boolean')
+    expect(output).toContain('"verbose": boolean')
   })
 
   test('array types', () => {
@@ -115,7 +115,7 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain('tags: string[]')
+    expect(output).toContain('"tags": string[]')
   })
 
   test('commands are sorted alphabetically', () => {
@@ -125,7 +125,7 @@ describe('fromCli', () => {
       .command('middle', { run: () => ({}) })
 
     const output = Typegen.fromCli(cli)
-    const commandOrder = [...output.matchAll(/^ {6}'(\w+)':/gm)].map((m) => m[1])
+    const commandOrder = [...output.matchAll(/^ {6}"(\w+)":/gm)].map((m) => m[1])
     expect(commandOrder).toEqual(['alpha', 'middle', 'zebra'])
   })
 
@@ -136,7 +136,7 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain('mode: "strict"')
+    expect(output).toContain('"mode": "strict"')
   })
 
   test('array of union items gets parens', () => {
@@ -146,7 +146,7 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain('values: (string | number)[]')
+    expect(output).toContain('"values": (string | number)[]')
   })
 
   test('null type', () => {
@@ -156,7 +156,7 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain('empty: null')
+    expect(output).toContain('"empty": null')
   })
 
   test('nested object with properties', () => {
@@ -166,7 +166,7 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain('config: { host: string; port: number }')
+    expect(output).toContain('"config": { "host": string; "port": number }')
   })
 
   test('optional properties use optional modifier', () => {
@@ -180,8 +180,8 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain('verbose?: boolean')
-    expect(output).toContain('output: string')
+    expect(output).toContain('"verbose"?: boolean | undefined')
+    expect(output).toContain('"output": string')
   })
 
   test('mixed top-level and grouped commands', () => {
@@ -194,8 +194,8 @@ describe('fromCli', () => {
       "declare module 'incur' {
         interface Register {
           commands: {
-            'ping': { args: {}; options: {} }
-            'pr list': { args: {}; options: {} }
+            "ping": { args: {}; options: {} }
+            "pr list": { args: {}; options: {} }
           }
         }
       }

--- a/src/Typegen.ts
+++ b/src/Typegen.ts
@@ -2,11 +2,13 @@ import fs from 'node:fs/promises'
 import { z } from 'zod'
 
 import * as Cli from './Cli.js'
+import { objectSchemaToType, propertyKey } from './internal/ts.js'
 import { importCli } from './internal/utils.js'
 
 /** Imports a CLI from `input` (must `export default` a `Cli`), generates the `.d.ts`, and writes it to `output`. */
 export async function generate(input: string, output: string): Promise<void> {
   const cli = await importCli(input)
+  await Cli.ready(cli)
   await fs.writeFile(output, fromCli(cli))
 }
 
@@ -21,7 +23,7 @@ export function fromCli(cli: Cli.Cli): string {
 
   for (const { name, args, options } of entries)
     lines.push(
-      `      '${name}': { args: ${schemaToType(args)}; options: ${schemaToType(options)} }`,
+      `      ${propertyKey(name)}: { args: ${objectSchemaToType(args)}; options: ${objectSchemaToType(options)} }`,
     )
 
   lines.push('    }', '  }', '}', '')
@@ -35,75 +37,16 @@ function collectEntries(
 ): { name: string; args?: z.ZodObject<any>; options?: z.ZodObject<any> }[] {
   const result: ReturnType<typeof collectEntries> = []
   for (const [name, entry] of commands) {
+    if ('_alias' in entry && entry._alias) {
+      const target = commands.get(entry.target)
+      if (!target) continue
+      const path = [...prefix, name]
+      result.push({ name: path.join(' '), args: target.args, options: target.options })
+      continue
+    }
     const path = [...prefix, name]
     if ('_group' in entry && entry._group) result.push(...collectEntries(entry.commands, path))
     else result.push({ name: path.join(' '), args: entry.args, options: entry.options })
   }
   return result.sort((a, b) => a.name.localeCompare(b.name))
-}
-
-/** Converts a Zod object schema to a TypeScript type string. Returns `{}` for undefined schemas. */
-function schemaToType(schema: z.ZodObject<any> | undefined): string {
-  if (!schema) return '{}'
-  const json = z.toJSONSchema(schema) as Record<string, unknown>
-  const defs = (json.$defs ?? {}) as Record<string, Record<string, unknown>>
-  const properties = json.properties as Record<string, Record<string, unknown>> | undefined
-  if (!properties || Object.keys(properties).length === 0) return '{}'
-  const required = new Set((json.required as string[] | undefined) ?? [])
-  const entries = Object.entries(properties).map(
-    ([key, value]) => `${key}${required.has(key) ? '' : '?'}: ${resolveType(value, defs)}`,
-  )
-  return `{ ${entries.join('; ')} }`
-}
-
-/** Recursively resolves a JSON Schema node to a TypeScript type string. */
-function resolveType(
-  schema: Record<string, unknown>,
-  defs: Record<string, Record<string, unknown>>,
-): string {
-  if (schema.$ref) {
-    const ref = (schema.$ref as string).replace('#/$defs/', '')
-    const resolved = defs[ref]
-    if (resolved) return resolveType(resolved, defs)
-    return 'unknown'
-  }
-
-  if ('const' in schema) return JSON.stringify(schema.const)
-  if (schema.enum) return (schema.enum as unknown[]).map((v) => JSON.stringify(v)).join(' | ')
-  if (schema.anyOf)
-    return (schema.anyOf as Record<string, unknown>[]).map((s) => resolveType(s, defs)).join(' | ')
-
-  const type = schema.type as string | string[] | undefined
-  if (Array.isArray(type))
-    return type
-      .map((t) => (t === 'null' ? 'null' : resolveType({ ...schema, type: t }, defs)))
-      .join(' | ')
-
-  switch (type) {
-    case 'string':
-      return 'string'
-    case 'number':
-    case 'integer':
-      return 'number'
-    case 'boolean':
-      return 'boolean'
-    case 'null':
-      return 'null'
-    case 'array': {
-      const items = schema.items as Record<string, unknown> | undefined
-      const itemType = items ? resolveType(items, defs) : 'unknown'
-      return itemType.includes(' | ') ? `(${itemType})[]` : `${itemType}[]`
-    }
-    case 'object': {
-      const properties = schema.properties as Record<string, Record<string, unknown>> | undefined
-      if (!properties || Object.keys(properties).length === 0) return '{}'
-      const required = new Set((schema.required as string[] | undefined) ?? [])
-      const entries = Object.entries(properties).map(
-        ([key, value]) => `${key}${required.has(key) ? '' : '?'}: ${resolveType(value, defs)}`,
-      )
-      return `{ ${entries.join('; ')} }`
-    }
-    default:
-      return 'unknown'
-  }
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { z } from 'zod'
 
 import * as Cli from './Cli.js'
+import * as Clientgen from './Clientgen.js'
 import * as ConfigSchema from './internal/configSchema.js'
 import { importCli } from './internal/utils.js'
 import * as Typegen from './Typegen.js'
@@ -18,6 +19,8 @@ const cli = Cli.create('incur', {
 }).command('gen', {
   description: 'Generate type definitions for development.',
   options: z.object({
+    client: z.boolean().optional().describe('Generate a typed client module'),
+    clientOutput: z.string().optional().describe('Typed client output path (absolute)'),
     configSchema: z
       .boolean()
       .optional()
@@ -32,9 +35,17 @@ const cli = Cli.create('incur', {
     const output = c.options.output ?? path.join(dir, 'incur.generated.ts')
 
     const cli = await importCli(entry)
+    await Cli.ready(cli)
     await fs.writeFile(output, Typegen.fromCli(cli))
 
     const result: Record<string, unknown> = { dir, entry, output }
+
+    if (c.options.client) {
+      const clientOutput =
+        c.options.clientOutput ?? path.join(path.dirname(output), 'incur.client.ts')
+      await fs.writeFile(clientOutput, Clientgen.fromCli(cli))
+      result.clientOutput = clientOutput
+    }
 
     const configSchema = c.options.configSchema ?? ConfigSchema.hasConfig(cli)
     if (configSchema) {

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1603,30 +1603,30 @@ describe('typegen', () => {
       "declare module 'incur' {
         interface Register {
           commands: {
-            'api': { args: {}; options: {} }
-            'auth login': { args: {}; options: { hostname: string; web: boolean; scopes: string[] } }
-            'auth logout': { args: {}; options: {} }
-            'auth status': { args: {}; options: {} }
-            'config': { args: { key?: string }; options: {} }
-            'echo': { args: { message: string; repeat?: number }; options: { upper: boolean; prefix: string } }
-            'explode': { args: {}; options: {} }
-            'explode-clac': { args: {}; options: {} }
-            'noop': { args: {}; options: {} }
-            'ping': { args: {}; options: {} }
-            'project create': { args: { name: string }; options: { description: string; private: boolean } }
-            'project delete': { args: { id: string }; options: { force: boolean } }
-            'project deploy create': { args: { env: string }; options: { branch: string; dryRun: boolean } }
-            'project deploy rollback': { args: { deployId: string }; options: {} }
-            'project deploy status': { args: { deployId: string }; options: {} }
-            'project get': { args: { id: string }; options: {} }
-            'project list': { args: {}; options: { limit: number; sort: "name" | "created" | "updated"; archived: boolean } }
-            'slow': { args: {}; options: {} }
-            'stream': { args: {}; options: {} }
-            'stream-error': { args: {}; options: {} }
-            'stream-ok': { args: {}; options: {} }
-            'stream-text': { args: {}; options: {} }
-            'stream-throw': { args: {}; options: {} }
-            'validate-fail': { args: { email: string; age: number }; options: {} }
+            "api": { args: {}; options: {} }
+            "auth login": { args: {}; options: { "hostname": string; "web": boolean; "scopes": string[] } }
+            "auth logout": { args: {}; options: {} }
+            "auth status": { args: {}; options: {} }
+            "config": { args: { "key"?: string | undefined }; options: {} }
+            "echo": { args: { "message": string; "repeat"?: number | undefined }; options: { "upper": boolean; "prefix": string } }
+            "explode": { args: {}; options: {} }
+            "explode-clac": { args: {}; options: {} }
+            "noop": { args: {}; options: {} }
+            "ping": { args: {}; options: {} }
+            "project create": { args: { "name": string }; options: { "description": string; "private": boolean } }
+            "project delete": { args: { "id": string }; options: { "force": boolean } }
+            "project deploy create": { args: { "env": string }; options: { "branch": string; "dryRun": boolean } }
+            "project deploy rollback": { args: { "deployId": string }; options: {} }
+            "project deploy status": { args: { "deployId": string }; options: {} }
+            "project get": { args: { "id": string }; options: {} }
+            "project list": { args: {}; options: { "limit": number; "sort": "name" | "created" | "updated"; "archived": boolean } }
+            "slow": { args: {}; options: {} }
+            "stream": { args: {}; options: {} }
+            "stream-error": { args: {}; options: {} }
+            "stream-ok": { args: {}; options: {} }
+            "stream-text": { args: {}; options: {} }
+            "stream-throw": { args: {}; options: {} }
+            "validate-fail": { args: { "email": string; "age": number }; options: {} }
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export { z } from 'zod'
 export * as Cli from './Cli.js'
+export * as Client from './Client.js'
+export * as Clientgen from './Clientgen.js'
 export * as Completions from './Completions.js'
 export { default as middleware } from './middleware.js'
 export type { Handler as MiddlewareHandler, Context as MiddlewareContext } from './middleware.js'

--- a/src/internal/command.ts
+++ b/src/internal/command.ts
@@ -82,11 +82,15 @@ export async function execute(command: any, options: execute.Options): Promise<e
       const parsed = Parser.parse(argv, { args: command.args })
       args = parsed.args
       parsedOptions = command.options ? command.options.parse(inputOptions) : {}
-    } else {
+    } else if (parseMode === 'flat') {
       // MCP mode: all params come from inputOptions, split into args vs options
       const split = splitParams(inputOptions, command)
       args = command.args ? command.args.parse(split.args) : {}
       parsedOptions = command.options ? command.options.parse(split.options) : {}
+    } else {
+      // RPC mode: args and options are already separate structured objects
+      args = command.args ? command.args.parse(options.inputArgs ?? {}) : {}
+      parsedOptions = command.options ? command.options.parse(inputOptions) : {}
     }
 
     // Parse env
@@ -296,8 +300,11 @@ export declare namespace execute {
      * - `'argv'` (default): parse both args and options from argv tokens (CLI mode)
      * - `'split'`: args from argv, options from inputOptions (HTTP mode)
      * - `'flat'`: all params from inputOptions, split by schema shapes (MCP mode)
+     * - `'structured'`: args from inputArgs, options from inputOptions (RPC mode)
      */
-    parseMode?: 'argv' | 'split' | 'flat' | undefined
+    parseMode?: 'argv' | 'split' | 'flat' | 'structured' | undefined
+    /** Raw parsed args for structured transports. */
+    inputArgs?: Record<string, unknown> | undefined
     /** The resolved command path. */
     path: string
     /** Vars schema for middleware variables. */

--- a/src/internal/ts.ts
+++ b/src/internal/ts.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod'
+
+export function propertyKey(key: string): string {
+  return JSON.stringify(key)
+}
+
+export function schemaHasProperties(schema: z.ZodObject<any> | undefined): boolean {
+  if (!schema) return false
+  return Object.keys(schema.shape).length > 0
+}
+
+export function schemaHasRequiredProperties(schema: z.ZodObject<any> | undefined): boolean {
+  if (!schema) return false
+  const json = z.toJSONSchema(schema) as Record<string, unknown>
+  return ((json.required as string[] | undefined) ?? []).length > 0
+}
+
+/** Converts a Zod schema to a TypeScript type string. */
+export function schemaToType(schema: z.ZodType | undefined): string {
+  if (!schema) return '{}'
+  const json = z.toJSONSchema(schema) as Record<string, unknown>
+  const defs = (json.$defs ?? {}) as Record<string, Record<string, unknown>>
+  return resolveType(json, defs)
+}
+
+/** Converts a Zod object schema to a TypeScript object type string. */
+export function objectSchemaToType(schema: z.ZodObject<any> | undefined): string {
+  if (!schema) return '{}'
+  return schemaToType(schema)
+}
+
+function resolveType(
+  schema: Record<string, unknown>,
+  defs: Record<string, Record<string, unknown>>,
+): string {
+  if (schema.$ref) {
+    const ref = (schema.$ref as string).replace('#/$defs/', '')
+    const resolved = defs[ref]
+    if (resolved) return resolveType(resolved, defs)
+    return 'unknown'
+  }
+
+  if ('const' in schema) return JSON.stringify(schema.const)
+  if (schema.enum) return (schema.enum as unknown[]).map((v) => JSON.stringify(v)).join(' | ')
+  if (schema.anyOf)
+    return (schema.anyOf as Record<string, unknown>[]).map((s) => resolveType(s, defs)).join(' | ')
+
+  const type = schema.type as string | string[] | undefined
+  if (Array.isArray(type))
+    return type
+      .map((t) => (t === 'null' ? 'null' : resolveType({ ...schema, type: t }, defs)))
+      .join(' | ')
+
+  switch (type) {
+    case 'string':
+      return 'string'
+    case 'number':
+    case 'integer':
+      return 'number'
+    case 'boolean':
+      return 'boolean'
+    case 'null':
+      return 'null'
+    case 'array': {
+      const items = schema.items as Record<string, unknown> | undefined
+      const itemType = items ? resolveType(items, defs) : 'unknown'
+      return itemType.includes(' | ') ? `(${itemType})[]` : `${itemType}[]`
+    }
+    case 'object': {
+      const properties = schema.properties as Record<string, Record<string, unknown>> | undefined
+      if (!properties || Object.keys(properties).length === 0) return '{}'
+      const required = new Set((schema.required as string[] | undefined) ?? [])
+      const entries = Object.entries(properties).map(([key, value]) => {
+        const type = resolveType(value, defs)
+        return required.has(key)
+          ? `${propertyKey(key)}: ${type}`
+          : `${propertyKey(key)}?: ${type} | undefined`
+      })
+      return `{ ${entries.join('; ')} }`
+    }
+    default:
+      return 'unknown'
+  }
+}


### PR DESCRIPTION
Adds generated TypeScript clients for incur CLIs.\n\nWhat changed:\n- Adds a structured POST /_incur/rpc route so generated clients can call commands with separate args and options without URL/query flattening.\n- Adds a public Client runtime and Clientgen generator that preserve exact command and group names as property keys, including aliases and hazardous names like __proto__/constructor/then.\n- Adds result clients for full envelopes and separate root-command client factories instead of making the main client callable.\n- Carries output schemas from generated OpenAPI commands into client output types.\n- Adds incur gen --client plus README and changeset coverage.\n\nValidation:\n- CI=true pnpm run check\n- CI=true pnpm run check:types\n- CI=true pnpm test\n- CI=true pnpm run build