### PR TITLE
fix: normalize object validation errors

### DIFF
--- a/.changeset/quiet-walls-share.md
+++ b/.changeset/quiet-walls-share.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Fixed HTTP and MCP command input validation to return standard validation field errors for object-shaped inputs.

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import * as Command from './internal/command.js'
+
 const originalIsTTY = process.stdout.isTTY
 beforeAll(() => {
   ;(process.stdout as any).isTTY = false
@@ -4048,6 +4050,74 @@ describe('--filter-output', () => {
     const { output } = await serve(cli, ['user', '--filter-output', 'name,age', '--format', 'json'])
     const parsed = JSON.parse(output)
     expect(parsed).toEqual({ name: 'alice', age: 30 })
+  })
+})
+
+describe('Command.execute', () => {
+  test.each([
+    {
+      name: 'split',
+      command: { options: z.object({ name: z.string() }), run: () => ({ ok: true }) },
+      inputOptions: { name: 123 },
+      path: 'name',
+      parseMode: 'split' as const,
+    },
+    {
+      name: 'flat',
+      command: { args: z.object({ id: z.string() }), run: () => ({ ok: true }) },
+      inputOptions: { id: 123 },
+      path: 'id',
+      parseMode: 'flat' as const,
+    },
+  ])('$name mode returns validation fieldErrors for invalid command input', async (c) => {
+    const result = await Command.execute(c.command, {
+      agent: true,
+      argv: [],
+      format: 'json',
+      formatExplicit: false,
+      inputOptions: c.inputOptions,
+      name: 'test',
+      parseMode: c.parseMode,
+      path: 'users',
+      version: undefined,
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        fieldErrors: [
+          {
+            code: 'invalid_type',
+            missing: false,
+            path: c.path,
+          },
+        ],
+      },
+    })
+  })
+
+  test('does not normalize handler-thrown Zod errors as command input', async () => {
+    const result = await Command.execute(
+      {
+        run() {
+          z.object({ name: z.string() }).parse({ name: 123 })
+        },
+      },
+      {
+        agent: true,
+        argv: [],
+        format: 'json',
+        formatExplicit: false,
+        inputOptions: {},
+        name: 'test',
+        path: 'users',
+        version: undefined,
+      },
+    )
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'UNKNOWN' } })
+    expect(result).not.toHaveProperty('error.fieldErrors')
   })
 })
 

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -4328,6 +4328,38 @@ describe('fetch', () => {
     expect(body.error.code).toBe('VALIDATION_ERROR')
   })
 
+  test('object validation error includes fieldErrors', async () => {
+    const cli = Cli.create('test')
+    cli.command('users', {
+      options: z.object({ name: z.string() }),
+      run: (c) => ({ name: c.options.name }),
+    })
+
+    const { status, body } = await fetchJson(
+      cli,
+      new Request('http://localhost/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 123 }),
+      }),
+    )
+
+    expect(status).toBe(400)
+    expect(body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        fieldErrors: [
+          {
+            code: 'invalid_type',
+            missing: false,
+            path: 'name',
+          },
+        ],
+      },
+    })
+  })
+
   test('thrown error → 500', async () => {
     const cli = Cli.create('test')
     cli.command('fail', {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -1906,6 +1906,7 @@ async function executeCommand(
           ...(result.error.retryable !== undefined
             ? { retryable: result.error.retryable }
             : undefined),
+          ...(result.error.fieldErrors ? { fieldErrors: result.error.fieldErrors } : undefined),
         },
         meta: {
           command: path,

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -257,7 +257,7 @@ function setOption(
 }
 
 /** Wraps zod schema.parse(), converting ZodError to ValidationError. */
-function zodParse(schema: z.ZodObject<any>, data: Record<string, unknown>) {
+export function zodParse(schema: z.ZodObject<any>, data: Record<string, unknown>) {
   try {
     return schema.parse(data)
   } catch (err: any) {

--- a/src/internal/command.ts
+++ b/src/internal/command.ts
@@ -81,12 +81,12 @@ export async function execute(command: any, options: execute.Options): Promise<e
       // HTTP mode: positional args from URL path segments, options from body/query
       const parsed = Parser.parse(argv, { args: command.args })
       args = parsed.args
-      parsedOptions = command.options ? command.options.parse(inputOptions) : {}
+      parsedOptions = command.options ? Parser.zodParse(command.options, inputOptions) : {}
     } else {
       // MCP mode: all params come from inputOptions, split into args vs options
       const split = splitParams(inputOptions, command)
-      args = command.args ? command.args.parse(split.args) : {}
-      parsedOptions = command.options ? command.options.parse(split.options) : {}
+      args = command.args ? Parser.zodParse(command.args, split.args) : {}
+      parsedOptions = command.options ? Parser.zodParse(command.options, split.options) : {}
     }
 
     // Parse env


### PR DESCRIPTION
## Overview

Normalize validation errors for structured command input.

CLI argv parsing already turns Zod failures into incur's standard `VALIDATION_ERROR` shape with `fieldErrors`. HTTP-style execution (`split`) and MCP-style execution (`flat`) were using raw Zod `.parse()`, so the same kind of invalid command input could come back as a generic `UNKNOWN` error instead.

## Issue

`Command.execute()` has three parsing modes:

- `argv`: CLI tokens.
- `split`: positional args from argv, options from an object. This is used by HTTP command routes.
- `flat`: one object split into args/options. This is used by MCP-style calls.

Before this PR, only `argv` went through incur's validation wrapper. The object-based modes called Zod directly:

```ts
command.options.parse(inputOptions)
command.args.parse(split.args)
command.options.parse(split.options)
```

That meant bad structured input like this:

```ts
inputOptions: { name: 123 } // schema expects string
parseMode: 'split'
```

did not produce the same structured field error as CLI input.

## Tests failing before fix

[`src/Cli.test.ts`](https://github.com/0xpolarzero/incur/blob/parse-object-validation/src/Cli.test.ts#L4056) adds direct executor coverage for both object-based modes.

For `split` and `flat`, invalid command input now returns:

```ts
{
  ok: false,
  error: {
    code: 'VALIDATION_ERROR',
    fieldErrors: [{ code: 'invalid_type', missing: false, path: 'name' }]
  }
}
```

[`src/Cli.test.ts`](https://github.com/0xpolarzero/incur/blob/parse-object-validation/src/Cli.test.ts#L4100) also guards the boundary: if user code throws a Zod error inside `run()`, it is still treated as a handler error, not as command input validation.

```ts
run() {
  z.object({ name: z.string() }).parse({ name: 123 })
}
```

Expected result:

```ts
{ ok: false, error: { code: 'UNKNOWN' } }
```

## Fix

[`Parser.zodParse()`](https://github.com/0xpolarzero/incur/blob/parse-object-validation/src/Parser.ts#L260) is exported so the command executor can reuse the existing Zod-to-`ValidationError` conversion.

[`Command.execute()`](https://github.com/0xpolarzero/incur/blob/parse-object-validation/src/internal/command.ts#L80) now uses that wrapper for:

- `split` options.
- `flat` args.
- `flat` options.

The change is intentionally narrow: only command input parsing is normalized. Handler-thrown Zod errors still follow the normal handler error path.
