### PR TITLE
feat(4): support streaming typed clients

### DIFF
--- a/.changeset/quiet-walls-share.md
+++ b/.changeset/quiet-walls-share.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Fixed HTTP and MCP command input validation to return standard validation field errors for object-shaped inputs.

--- a/.changeset/sharp-rivers-notice.md
+++ b/.changeset/sharp-rivers-notice.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Added a structured RPC endpoint for command execution over HTTP.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - **`const` generics on definitions** — any function that accepts Zod schemas and passes them to callbacks must use `const` generic parameters to preserve literal types (e.g. `<const args extends z.ZodObject<any>>`).
 - **Flow schemas through generics** — when a factory function accepts Zod schemas, use generics to flow `z.output<>` through to callbacks (`run`, `next`), return types, and constraint types (`alias`). Never fall back to `any` in callback signatures.
 - **Type tests in `.test-d.ts`** — use vitest's `expectTypeOf` in colocated `.test-d.ts` files to assert generic inference works. Type tests are first-class — write them alongside implementation, not as an afterthought.
+- **Avoid global declaration merging in type tests** — module augmentation in `.test-d.ts` affects the full `tsc -b` project, so prefer explicit generics/local helper types unless the test is specifically about global registration behavior.
 - **No `any` leakage** — Zod schemas may use `z.ZodObject<any>` as a generic bound, but inferred types flowing to user-facing callbacks must be narrowed via `z.output<typeof schema>`. The user should never see `any` in their IDE.
 - **Type inference after every feature** — after implementing any feature, check if new types can be narrowed. If a new property, callback, or return type touches a Zod schema, add generics to flow the inferred type through. Add or update `.test-d.ts` type tests alongside.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 
 - **`z.output<>` over `z.infer<>`** — use `z.output<schema>` for types after transforms/defaults are applied (what `schema.parse()` returns at runtime). Use `z.input<schema>` only when representing pre-validation types.
 - **`const` generics on definitions** — any function that accepts Zod schemas and passes them to callbacks must use `const` generic parameters to preserve literal types (e.g. `<const args extends z.ZodObject<any>>`).
+- **Streaming commands use `async *run`** — typed client/typegen stream detection is based on the handler being an async generator function. Do not hide streaming behind `run() { return stream() }` when generated client types should be streaming-aware.
 - **Flow schemas through generics** — when a factory function accepts Zod schemas, use generics to flow `z.output<>` through to callbacks (`run`, `next`), return types, and constraint types (`alias`). Never fall back to `any` in callback signatures.
 - **Type tests in `.test-d.ts`** — use vitest's `expectTypeOf` in colocated `.test-d.ts` files to assert generic inference works. Type tests are first-class — write them alongside implementation, not as an afterthought.
 - **Avoid global declaration merging in type tests** — module augmentation in `.test-d.ts` affects the full `tsc -b` project, so prefer explicit generics/local helper types unless the test is specifically about global registration behavior.

--- a/README.md
+++ b/README.md
@@ -380,6 +380,27 @@ Responses use the same JSON envelope as `--full-output --format json`:
 
 Async generator commands stream as NDJSON (`application/x-ndjson`). Middleware runs the same as in `serve()`.
 
+#### RPC
+
+The `fetch` handler also exposes `POST /_incur/rpc` for structured command calls. Use it when a client already has separated `args` and `options` objects and should not encode positional args into the URL path:
+
+```http
+POST /_incur/rpc
+content-type: application/json
+
+{
+  "command": "users",
+  "args": { "id": 42 },
+  "options": { "limit": 5 }
+}
+```
+
+The response uses the same JSON envelope as command API responses.
+
+Raw fetch gateways mounted with `command('api', { fetch })` are intentionally not supported by
+structured RPC because they accept arbitrary HTTP requests instead of a known command schema. Mount
+the gateway with an OpenAPI spec to generate typed operations, or call the HTTP route directly.
+
 #### MCP over HTTP
 
 The `fetch` handler automatically exposes an MCP endpoint at `/mcp`. Agents can discover and call your CLI's commands as MCP tools over HTTP — no stdio required:

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ cli.command('deploy', {
 
 ### Streaming
 
-Use `async *run` to stream chunks incrementally. Yield objects for structured data or plain strings for text:
+Use `async *run` to stream chunks incrementally. Yield objects for structured data or plain strings for text. Generated client types recognize streaming commands from this `async *run` shape:
 
 ```ts
 cli.command('logs', {

--- a/SKILL.md
+++ b/SKILL.md
@@ -931,7 +931,7 @@ Bun.serve(cli)
 
 ## Streaming
 
-Use `async *run` to stream chunks incrementally. Yield objects for structured data or plain strings for text:
+Use `async *run` to stream chunks incrementally. Yield objects for structured data or plain strings for text. Generated client types recognize streaming commands from this `async *run` shape:
 
 ```ts
 cli.command('logs', {

--- a/SKILL.md
+++ b/SKILL.md
@@ -971,7 +971,14 @@ Generate type definitions for your CLI's command map to get typed CTAs:
 incur gen
 ```
 
-This creates a `incur.generated.ts` file that registers your commands on the `Cli.Commands` type, enabling autocomplete on CTA command names, args, and options.
+This creates a `incur.generated.ts` file that registers your commands on the `Cli.Commands` type, enabling autocomplete on CTA command names, args, and options. It also exports a `Commands` type you can import and pass to `createClient` when calling the CLI over RPC:
+
+```ts
+import { createClient } from 'incur'
+import type { Commands } from './incur.generated.js'
+
+const client = createClient<Commands>({ baseUrl: 'https://api.example.com' })
+```
 
 ## Full Example
 

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -278,7 +278,7 @@ test('OpenAPI mounted fetch accumulates operation command types', () => {
   }>()
   expectTypeOf<Commands['api createUser']>().toExtend<{
     args: {}
-    options: { name: string; active?: boolean | undefined }
+    options: { name?: string | undefined; active?: boolean | undefined }
     output: { id: number; name: string }
   }>()
   expectTypeOf<Commands['api getUser']>().toExtend<{
@@ -290,6 +290,22 @@ test('OpenAPI mounted fetch accumulates operation command types', () => {
   // @ts-expect-error raw gateway name is not a generated command
   type RawGateway = Commands['api']
   void (undefined as unknown as RawGateway)
+})
+
+test('mounted root CLI preserves output type in command map', () => {
+  const deploy = Cli.create('deploy', {
+    output: z.object({ id: z.string(), status: z.literal('queued') }),
+    run: () => ({ id: 'dep_123', status: 'queued' as const }),
+  })
+
+  const cli = Cli.create('test').command(deploy)
+
+  type Commands = typeof cli extends Cli.Cli<infer commands> ? commands : never
+  expectTypeOf<Commands['deploy']>().toExtend<{
+    args: {}
+    options: {}
+    output: { id: string; status: 'queued' }
+  }>()
 })
 
 test('middleware<typeof cli.vars>() infers vars types', () => {

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -167,6 +167,131 @@ test('command() accumulates command types through chaining', () => {
   expectTypeOf<Commands['list']>().toEqualTypeOf<{ args: {}; options: { limit: number } }>()
 })
 
+test('OpenAPI mounted fetch accumulates operation command types', () => {
+  const spec = {
+    openapi: '3.0.0',
+    info: { title: 'Test', version: '1.0.0' },
+    paths: {
+      '/users': {
+        get: {
+          operationId: 'listUsers',
+          parameters: [
+            {
+              name: 'limit',
+              in: 'query',
+              schema: { type: 'number' },
+            },
+          ],
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      users: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: { id: { type: 'number' }, name: { type: 'string' } },
+                          required: ['id', 'name'],
+                        },
+                      },
+                    },
+                    required: ['users'],
+                  },
+                },
+              },
+            },
+          },
+        },
+        post: {
+          operationId: 'createUser',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' }, active: { type: 'boolean' } },
+                  required: ['name'],
+                },
+              },
+            },
+          },
+          responses: {
+            201: {
+              description: 'Created',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { id: { type: 'number' }, name: { type: 'string' } },
+                    required: ['id', 'name'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/users/{id}': {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'number' },
+          },
+        ],
+        get: {
+          operationId: 'getUser',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { id: { type: 'number' }, name: { type: 'string' } },
+                    required: ['id', 'name'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  } as const
+
+  const cli = Cli.create('test').command('api', {
+    fetch: () => new Response(),
+    openapi: spec,
+  })
+
+  type Commands = typeof cli extends Cli.Cli<infer commands> ? commands : never
+  expectTypeOf<Commands['api listUsers']>().toExtend<{
+    args: {}
+    options: { limit?: number | undefined }
+    output: { users: { id: number; name: string }[] }
+  }>()
+  expectTypeOf<Commands['api createUser']>().toExtend<{
+    args: {}
+    options: { name: string; active?: boolean | undefined }
+    output: { id: number; name: string }
+  }>()
+  expectTypeOf<Commands['api getUser']>().toExtend<{
+    args: { id: number }
+    options: {}
+    output: { id: number; name: string }
+  }>()
+
+  // @ts-expect-error raw gateway name is not a generated command
+  type RawGateway = Commands['api']
+  void (undefined as unknown as RawGateway)
+})
+
 test('middleware<typeof cli.vars>() infers vars types', () => {
   const cli = Cli.create('test', {
     vars: z.object({ user: z.string(), count: z.number() }),

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import * as Command from './internal/command.js'
+
 const originalIsTTY = process.stdout.isTTY
 beforeAll(() => {
   ;(process.stdout as any).isTTY = false
@@ -4048,6 +4050,74 @@ describe('--filter-output', () => {
     const { output } = await serve(cli, ['user', '--filter-output', 'name,age', '--format', 'json'])
     const parsed = JSON.parse(output)
     expect(parsed).toEqual({ name: 'alice', age: 30 })
+  })
+})
+
+describe('Command.execute', () => {
+  test.each([
+    {
+      name: 'split',
+      command: { options: z.object({ name: z.string() }), run: () => ({ ok: true }) },
+      inputOptions: { name: 123 },
+      path: 'name',
+      parseMode: 'split' as const,
+    },
+    {
+      name: 'flat',
+      command: { args: z.object({ id: z.string() }), run: () => ({ ok: true }) },
+      inputOptions: { id: 123 },
+      path: 'id',
+      parseMode: 'flat' as const,
+    },
+  ])('$name mode returns validation fieldErrors for invalid command input', async (c) => {
+    const result = await Command.execute(c.command, {
+      agent: true,
+      argv: [],
+      format: 'json',
+      formatExplicit: false,
+      inputOptions: c.inputOptions,
+      name: 'test',
+      parseMode: c.parseMode,
+      path: 'users',
+      version: undefined,
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        fieldErrors: [
+          {
+            code: 'invalid_type',
+            missing: false,
+            path: c.path,
+          },
+        ],
+      },
+    })
+  })
+
+  test('does not normalize handler-thrown Zod errors as command input', async () => {
+    const result = await Command.execute(
+      {
+        run() {
+          z.object({ name: z.string() }).parse({ name: 123 })
+        },
+      },
+      {
+        agent: true,
+        argv: [],
+        format: 'json',
+        formatExplicit: false,
+        inputOptions: {},
+        name: 'test',
+        path: 'users',
+        version: undefined,
+      },
+    )
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'UNKNOWN' } })
+    expect(result).not.toHaveProperty('error.fieldErrors')
   })
 })
 

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -4069,12 +4069,21 @@ describe('Command.execute', () => {
       path: 'id',
       parseMode: 'flat' as const,
     },
+    {
+      name: 'structured',
+      command: { args: z.object({ id: z.string() }), run: () => ({ ok: true }) },
+      inputArgs: { id: 123 },
+      inputOptions: {},
+      path: 'id',
+      parseMode: 'structured' as const,
+    },
   ])('$name mode returns validation fieldErrors for invalid command input', async (c) => {
     const result = await Command.execute(c.command, {
       agent: true,
       argv: [],
       format: 'json',
       formatExplicit: false,
+      inputArgs: 'inputArgs' in c ? c.inputArgs : undefined,
       inputOptions: c.inputOptions,
       name: 'test',
       parseMode: c.parseMode,
@@ -4269,6 +4278,98 @@ describe('fetch', () => {
         "status": 200,
       }
     `)
+  })
+
+  test('POST /_incur/rpc executes command with structured args and options', async () => {
+    const cli = Cli.create('test')
+    cli.command('math/sum', {
+      args: z.object({ left: z.number() }),
+      options: z.object({ right: z.number() }),
+      run: (c) => ({ value: c.args.left + c.options.right }),
+    })
+
+    const req = new Request('http://localhost/_incur/rpc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        command: 'math/sum',
+        args: { left: 1 },
+        options: { right: 2 },
+      }),
+    })
+
+    expect(await fetchJson(cli, req)).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "value": 3,
+          },
+          "meta": {
+            "command": "math/sum",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('POST /_incur/rpc rejects non-object args and options', async () => {
+    const cli = Cli.create('test').command('ping', { run: () => ({ ok: true }) })
+    const req = new Request('http://localhost/_incur/rpc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ command: 'ping', args: [] }),
+    })
+
+    const { status, body } = await fetchJson(cli, req)
+    expect(status).toBe(400)
+    expect(body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: '`args` and `options` must be objects.',
+    })
+  })
+
+  test('POST /_incur/rpc rejects raw fetch gateways', async () => {
+    const cli = Cli.create('test').command('api', {
+      fetch: () => new Response(JSON.stringify({ ok: true })),
+    })
+    const req = new Request('http://localhost/_incur/rpc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ command: 'api' }),
+    })
+
+    const { status, body } = await fetchJson(cli, req)
+    expect(status).toBe(400)
+    expect(body.error).toEqual({
+      code: 'FETCH_GATEWAY_UNSUPPORTED',
+      message:
+        'Raw fetch gateways cannot be called through structured RPC. Mount the gateway with an OpenAPI spec to generate typed commands, or call the HTTP route directly.',
+    })
+  })
+
+  test('POST /_incur/rpc returns validation field errors', async () => {
+    const cli = Cli.create('test').command('sum', {
+      args: z.object({ left: z.number() }),
+      run: (c) => ({ value: c.args.left }),
+    })
+    const req = new Request('http://localhost/_incur/rpc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ command: 'sum', args: {} }),
+    })
+
+    const { status, body } = await fetchJson(cli, req)
+    expect(status).toBe(400)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.fieldErrors).toMatchObject([
+      {
+        missing: true,
+        path: 'left',
+      },
+    ])
   })
 
   test('trailing path segments → positional args', async () => {

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -4372,6 +4372,147 @@ describe('fetch', () => {
     ])
   })
 
+  test('POST /_incur/rpc streams async generator output as NDJSON', async () => {
+    const cli = Cli.create('test')
+    cli.command('stream', {
+      args: z.object({ start: z.number() }),
+      options: z.object({ step: z.number() }),
+      async *run(c) {
+        yield { progress: c.args.start }
+        yield { progress: c.args.start + c.options.step }
+        return { done: c.args.start + c.options.step * 2 }
+      },
+    })
+    const res = await cli.fetch(
+      new Request('http://localhost/_incur/rpc', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          command: 'stream',
+          args: { start: 2 },
+          options: { step: 3 },
+        }),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('application/x-ndjson')
+    const lines = (await res.text())
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+    expect(lines).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {
+            "progress": 2,
+          },
+          "type": "chunk",
+        },
+        {
+          "data": {
+            "progress": 5,
+          },
+          "type": "chunk",
+        },
+        {
+          "meta": {
+            "command": "stream",
+          },
+          "ok": true,
+          "type": "done",
+        },
+      ]
+    `)
+  })
+
+  test('POST /_incur/rpc stream preserves returned ok CTA', async () => {
+    const cli = Cli.create('test')
+    cli.command('stream', {
+      async *run(c) {
+        yield { progress: 1 }
+        return c.ok(undefined, { cta: { commands: ['status'] } })
+      },
+    })
+    const res = await cli.fetch(
+      new Request('http://localhost/_incur/rpc', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ command: 'stream', args: {}, options: {} }),
+      }),
+    )
+
+    const lines = (await res.text())
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+    expect(lines).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {
+            "progress": 1,
+          },
+          "type": "chunk",
+        },
+        {
+          "meta": {
+            "command": "stream",
+            "cta": {
+              "commands": [
+                {
+                  "command": "test status",
+                },
+              ],
+              "description": "Suggested command:",
+            },
+          },
+          "ok": true,
+          "type": "done",
+        },
+      ]
+    `)
+  })
+
+  test('POST /_incur/rpc stream preserves returned errors', async () => {
+    const cli = Cli.create('test')
+    cli.command('stream', {
+      async *run(c) {
+        yield { progress: 1 }
+        return c.error({ code: 'STREAM_FAIL', message: 'broke' })
+      },
+    })
+    const res = await cli.fetch(
+      new Request('http://localhost/_incur/rpc', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ command: 'stream', args: {}, options: {} }),
+      }),
+    )
+
+    const lines = (await res.text())
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+    expect(lines).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {
+            "progress": 1,
+          },
+          "type": "chunk",
+        },
+        {
+          "error": {
+            "code": "STREAM_FAIL",
+            "message": "broke",
+          },
+          "ok": false,
+          "type": "error",
+        },
+      ]
+    `)
+  })
+
   test('trailing path segments → positional args', async () => {
     const cli = Cli.create('test')
     cli.command('users', {
@@ -4491,6 +4632,79 @@ describe('fetch', () => {
           },
           "ok": true,
           "type": "done",
+        },
+      ]
+    `)
+  })
+
+  test('async generator RPC stream preserves returned ok CTA', async () => {
+    const cli = Cli.create('test')
+    cli.command('stream', {
+      async *run(c) {
+        yield { progress: 1 }
+        return c.ok(undefined, { cta: { commands: ['status'] } })
+      },
+    })
+    const res = await cli.fetch(new Request('http://localhost/stream'))
+    const lines = (await res.text())
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+    expect(lines).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {
+            "progress": 1,
+          },
+          "type": "chunk",
+        },
+        {
+          "meta": {
+            "command": "stream",
+            "cta": {
+              "commands": [
+                {
+                  "command": "test status",
+                },
+              ],
+              "description": "Suggested command:",
+            },
+          },
+          "ok": true,
+          "type": "done",
+        },
+      ]
+    `)
+  })
+
+  test('async generator RPC stream preserves returned errors', async () => {
+    const cli = Cli.create('test')
+    cli.command('stream', {
+      async *run(c) {
+        yield { progress: 1 }
+        return c.error({ code: 'STREAM_FAIL', message: 'broke' })
+      },
+    })
+    const res = await cli.fetch(new Request('http://localhost/stream'))
+    const lines = (await res.text())
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+    expect(lines).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {
+            "progress": 1,
+          },
+          "type": "chunk",
+        },
+        {
+          "error": {
+            "code": "STREAM_FAIL",
+            "message": "broke",
+          },
+          "ok": false,
+          "type": "error",
         },
       ]
     `)

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -1523,6 +1523,8 @@ declare namespace fetchImpl {
     envSchema?: z.ZodObject<any> | undefined
     /** Group-level middleware collected during command resolution. */
     groupMiddlewares?: MiddlewareHandler[] | undefined
+    /** Structured args received from the RPC route. */
+    structuredArgs?: Record<string, unknown> | undefined
     mcpHandler?:
       | ((
           req: Request,
@@ -1657,6 +1659,14 @@ async function fetchImpl(
       vars: options.vars,
     })
 
+  if (
+    req.method === 'POST' &&
+    segments[0] === '_incur' &&
+    segments[1] === 'rpc' &&
+    segments.length === 2
+  )
+    return executeRpcCommand(commands, req, start, options)
+
   // .well-known/skills/ — Agent Skills Discovery (RFC)
   if (
     segments[0] === '.well-known' &&
@@ -1776,6 +1786,69 @@ async function fetchImpl(
   })
 }
 
+/** @internal Executes an RPC client request. */
+async function executeRpcCommand(
+  commands: Map<string, CommandEntry>,
+  req: Request,
+  start: number,
+  options: fetchImpl.Options,
+): Promise<Response> {
+  function jsonResponse(body: unknown, status: number) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  function error(code: string, message: string, status: number, command = '/_incur/rpc') {
+    return jsonResponse(
+      {
+        ok: false,
+        error: { code, message },
+        meta: { command, duration: `${Math.round(performance.now() - start)}ms` },
+      },
+      status,
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return error('VALIDATION_ERROR', 'Request body must be JSON.', 400)
+  }
+
+  if (!isRecord(body)) return error('VALIDATION_ERROR', 'Request body must be an object.', 400)
+
+  if (typeof body.command !== 'string')
+    return error('VALIDATION_ERROR', '`command` must be a string.', 400)
+  const command = body.command.trim()
+  if (!command) return error('VALIDATION_ERROR', '`command` must be a non-empty string.', 400)
+
+  const args = body.args ?? {}
+  const rpcOptions = body.options ?? {}
+  if (!isRecord(args) || !isRecord(rpcOptions))
+    return error('VALIDATION_ERROR', '`args` and `options` must be objects.', 400)
+
+  const tokens = command.split(/\s+/)
+  const resolved = resolveCommand(commands, tokens)
+  if ('fetchGateway' in resolved)
+    return error(
+      'FETCH_GATEWAY_UNSUPPORTED',
+      'Raw fetch gateways cannot be called through structured RPC. Mount the gateway with an OpenAPI spec to generate typed commands, or call the HTTP route directly.',
+      400,
+      command,
+    )
+  if (!('command' in resolved) || resolved.rest.length > 0)
+    return error('COMMAND_NOT_FOUND', 'Command not found.', 404, command)
+
+  return executeCommand(resolved.path, resolved.command, [], rpcOptions, start, {
+    ...options,
+    groupMiddlewares: resolved.middlewares,
+    structuredArgs: args,
+  })
+}
+
 /** @internal Executes a resolved command for the fetch handler and returns a JSON Response. */
 async function executeCommand(
   path: string,
@@ -1804,10 +1877,11 @@ async function executeCommand(
     env: options.envSchema,
     format: 'json',
     formatExplicit: true,
+    inputArgs: options.structuredArgs,
     inputOptions,
     middlewares: allMiddleware,
     name: options.name ?? path,
-    parseMode: 'split',
+    parseMode: options.structuredArgs === undefined ? 'split' : 'structured',
     path,
     vars: options.vars,
     version: options.version,
@@ -1869,6 +1943,7 @@ async function executeCommand(
           ...(result.error.retryable !== undefined
             ? { retryable: result.error.retryable }
             : undefined),
+          ...(result.error.fieldErrors ? { fieldErrors: result.error.fieldErrors } : undefined),
         },
         meta: {
           command: path,

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -35,6 +35,8 @@ import * as Skill from './Skill.js'
 import * as SyncMcp from './SyncMcp.js'
 import * as SyncSkills from './SyncSkills.js'
 
+declare const rootType: unique symbol
+
 /** A CLI application instance. Also used as a command group when mounted on a parent CLI. */
 export type Cli<
   commands extends CommandsMap = {},
@@ -53,23 +55,20 @@ export type Cli<
     >(
       name: name,
       definition: CommandDefinition<args, cmdEnv, options, output, vars, env>,
-    ): Cli<
-      commands & { [key in name]: CommandMapEntry<args, options, output> },
-      vars,
-      env
-    >
-    /** Mounts a sub-CLI as a command group. */
-    <const name extends string, const sub extends CommandsMap>(
-      cli: Cli<sub, any, any> & { name: name },
-    ): Cli<commands & { [key in keyof sub & string as `${name} ${key}`]: sub[key] }, vars, env>
+    ): Cli<commands & { [key in name]: CommandMapEntry<args, options, output> }, vars, env>
     /** Mounts a root CLI as a single command. */
     <
       const name extends string,
       const args extends z.ZodObject<any> | undefined,
       const opts extends z.ZodObject<any> | undefined,
+      const output extends z.ZodType | undefined,
     >(
-      cli: Root<args, opts> & { name: name },
-    ): Cli<commands & { [key in name]: CommandMapEntry<args, opts> }, vars, env>
+      cli: Root<args, opts, output> & { name: name },
+    ): Cli<commands & { [key in name]: CommandMapEntry<args, opts, output> }, vars, env>
+    /** Mounts a sub-CLI as a command group. */
+    <const name extends string, const sub extends CommandsMap>(
+      cli: Cli<sub, any, any> & { name: name },
+    ): Cli<commands & { [key in keyof sub & string as `${name} ${key}`]: sub[key] }, vars, env>
     /** Mounts a fetch handler with an OpenAPI spec as a typed command group. */
     <const name extends string, const spec extends Openapi.OpenAPISpec>(
       name: name,
@@ -113,7 +112,11 @@ export type Cli<
 export type Root<
   _args extends z.ZodObject<any> | undefined = undefined,
   _options extends z.ZodObject<any> | undefined = undefined,
-> = Omit<Cli, 'command'>
+  _output extends z.ZodType | undefined = undefined,
+> = Omit<Cli, 'command'> & {
+  /** @internal Carries root command schemas for mount inference. */
+  [rootType]: { args: _args; options: _options; output: _output }
+}
 
 /** Extracts the commands map from the registered type. */
 export type Commands = Register extends { commands: infer commands extends CommandsMap }
@@ -172,7 +175,8 @@ export function create<
 >(
   name: string,
   definition: create.Options<args, env, opts, output, vars> & { run: Function },
-): Cli<{ [key in typeof name]: CommandMapEntry<args, opts, output> }, vars, env>
+): Cli<{ [key in typeof name]: CommandMapEntry<args, opts, output> }, vars, env> &
+  Root<args, opts, output>
 /** Creates a router CLI that registers subcommands. */
 export function create<
   const args extends z.ZodObject<any> | undefined = undefined,
@@ -196,7 +200,8 @@ export function create<
   },
   vars,
   env
->
+> &
+  Root<args, opts, output>
 /** Creates a router CLI from a single options object (e.g. package.json). */
 export function create<
   const args extends z.ZodObject<any> | undefined = undefined,

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -220,7 +220,8 @@ export function create(
 ): Cli | Root {
   const name = typeof nameOrDefinition === 'string' ? nameOrDefinition : nameOrDefinition.name
   const def = typeof nameOrDefinition === 'string' ? (definition ?? {}) : nameOrDefinition
-  const rootDef = 'run' in def ? (def as CommandDefinition<any, any, any>) : undefined
+  const rootDef =
+    'run' in def ? annotateStreamingCommand(def as CommandDefinition<any, any, any>) : undefined
   const rootFetch = 'fetch' in def ? (def.fetch as FetchHandler) : undefined
 
   const commands = new Map<string, CommandEntry>()
@@ -258,7 +259,7 @@ export function create(
           } as InternalFetchGateway)
           return cli
         }
-        commands.set(nameOrCli, def)
+        commands.set(nameOrCli, annotateStreamingCommand(def))
         if (def.aliases)
           for (const a of def.aliases) commands.set(a, { _alias: true, target: nameOrCli })
         return cli
@@ -1904,34 +1905,68 @@ async function executeCommand(
     const stream = new ReadableStream({
       async start(controller) {
         const encoder = new TextEncoder()
+        const write = (value: unknown) => {
+          controller.enqueue(encoder.encode(JSON.stringify(value) + '\n'))
+        }
         try {
-          for await (const value of result.stream) {
-            controller.enqueue(
-              encoder.encode(JSON.stringify({ type: 'chunk', data: value }) + '\n'),
-            )
-          }
-          controller.enqueue(
-            encoder.encode(
-              JSON.stringify({
-                type: 'done',
-                ok: true,
-                meta: { command: path },
-              }) + '\n',
-            ),
-          )
-        } catch (error) {
-          controller.enqueue(
-            encoder.encode(
-              JSON.stringify({
+          let returnValue: unknown
+          while (true) {
+            const { value, done } = await result.stream.next()
+            if (done) {
+              returnValue = value
+              break
+            }
+            if (isSentinel(value) && value[sentinel] === 'error') {
+              const err = value as ErrorResult
+              write({
                 type: 'error',
                 ok: false,
                 error: {
-                  code: 'UNKNOWN',
-                  message: error instanceof Error ? error.message : String(error),
+                  code: err.code,
+                  message: err.message,
+                  ...(err.retryable !== undefined ? { retryable: err.retryable } : undefined),
                 },
-              }) + '\n',
-            ),
-          )
+              })
+              controller.close()
+              return
+            }
+            write({ type: 'chunk', data: value })
+          }
+          if (isSentinel(returnValue) && returnValue[sentinel] === 'error') {
+            const err = returnValue as ErrorResult
+            write({
+              type: 'error',
+              ok: false,
+              error: {
+                code: err.code,
+                message: err.message,
+                ...(err.retryable !== undefined ? { retryable: err.retryable } : undefined),
+              },
+            })
+            controller.close()
+            return
+          }
+          const cta =
+            isSentinel(returnValue) && returnValue[sentinel] === 'ok'
+              ? formatCtaBlock(options.name ?? path, (returnValue as OkResult).cta)
+              : undefined
+          write({
+            type: 'done',
+            ok: true,
+            meta: { command: path, ...(cta ? { cta } : undefined) },
+          })
+        } catch (error) {
+          write({
+            type: 'error',
+            ok: false,
+            error: {
+              code: error instanceof IncurError ? error.code : 'UNKNOWN',
+              message: error instanceof Error ? error.message : String(error),
+              ...(error instanceof IncurError && error.retryable !== undefined
+                ? { retryable: error.retryable }
+                : undefined),
+            },
+          })
         }
         controller.close()
       },
@@ -2498,6 +2533,8 @@ export type CommandsMap = Record<
     options: Record<string, unknown>
     /** Command output shape. */
     output?: unknown | undefined
+    /** Whether the command streams output chunks. */
+    stream?: true | undefined
   }
 >
 
@@ -2552,6 +2589,19 @@ type InternalAlias = {
 /** @internal Type guard for alias entries. */
 function isAlias(entry: CommandEntry): entry is InternalAlias {
   return '_alias' in entry
+}
+
+const AsyncGeneratorFunction = async function* () {}.constructor
+
+function isAsyncGeneratorFunction(value: unknown): boolean {
+  return typeof value === 'function' && value.constructor === AsyncGeneratorFunction
+}
+
+function annotateStreamingCommand<const command extends CommandDefinition<any, any, any>>(
+  command: command,
+): command {
+  if (isAsyncGeneratorFunction(command.run)) return { ...command, _stream: true } as command
+  return command
 }
 
 /** @internal Follows an alias entry to its canonical target. Returns the entry unchanged if not an alias. */
@@ -3160,6 +3210,8 @@ type CommandDefinition<
   vars extends z.ZodObject<any> | undefined = undefined,
   cliEnv extends z.ZodObject<any> | undefined = undefined,
 > = CommandMeta<options> & {
+  /** @internal Whether this command's handler is an async generator function. */
+  _stream?: true | undefined
   /** Alternative names for this command (e.g. `['extensions', 'ext']` for an `extension` command). */
   aliases?: string[] | undefined
   /** Zod schema for positional arguments. */
@@ -3188,41 +3240,50 @@ type CommandDefinition<
   /** Alternative usage patterns shown in help output. */
   usage?: Usage<args, options>[] | undefined
   /** The command handler. Return a value for single-return, or use `async *run` to stream chunks. */
-  run(context: {
-    /** Whether the consumer is an agent (stdout is not a TTY). */
-    agent: boolean
-    /** Positional arguments. */
-    args: InferOutput<args>
-    /** The binary name the user invoked (e.g. an alias). Falls back to `name` when not resolvable. */
-    displayName: string
-    /** Parsed environment variables. */
-    env: InferOutput<env>
-    /** Return an error result with optional CTAs. */
-    error: (options: {
-      code: string
-      cta?: CtaBlock | undefined
-      exitCode?: number | undefined
-      message: string
-      retryable?: boolean | undefined
-    }) => never
-    /** The resolved output format (e.g. `'toon'`, `'json'`, `'jsonl'`). */
-    format: Formatter.Format
-    /** Whether the user explicitly passed `--format` or `--json`. */
-    formatExplicit: boolean
-    /** The CLI name. */
-    name: string
-    /** Return a success result with optional metadata (e.g. CTAs). */
-    ok: (data: InferReturn<output>, meta?: { cta?: CtaBlock | undefined }) => never
-    options: InferOutput<options>
-    /** Variables set by middleware. */
-    var: InferVars<vars>
-    /** The CLI version string. */
-    version: string | undefined
-  }):
-    | InferReturn<output>
-    | Promise<InferReturn<output>>
-    | AsyncGenerator<InferReturn<output>, unknown, unknown>
+  run: CommandRun<args, env, options, output, vars>
 }
+
+type CommandRun<
+  args extends z.ZodObject<any> | undefined = undefined,
+  env extends z.ZodObject<any> | undefined = undefined,
+  options extends z.ZodObject<any> | undefined = undefined,
+  output extends z.ZodType | undefined = undefined,
+  vars extends z.ZodObject<any> | undefined = undefined,
+  cliEnv extends z.ZodObject<any> | undefined = undefined,
+> = (context: {
+  /** Whether the consumer is an agent (stdout is not a TTY). */
+  agent: boolean
+  /** Positional arguments. */
+  args: InferOutput<args>
+  /** The binary name the user invoked (e.g. an alias). Falls back to `name` when not resolvable. */
+  displayName: string
+  /** Parsed environment variables. */
+  env: InferOutput<env>
+  /** Return an error result with optional CTAs. */
+  error: (options: {
+    code: string
+    cta?: CtaBlock | undefined
+    exitCode?: number | undefined
+    message: string
+    retryable?: boolean | undefined
+  }) => never
+  /** The resolved output format (e.g. `'toon'`, `'jsonl'`). */
+  format: Formatter.Format
+  /** Whether the user explicitly passed `--format` or `--json`. */
+  formatExplicit: boolean
+  /** The CLI name. */
+  name: string
+  /** Return a success result with optional metadata (e.g. CTAs). */
+  ok: (data: InferReturn<output>, meta?: { cta?: CtaBlock | undefined }) => never
+  options: InferOutput<options>
+  /** Variables set by middleware. */
+  var: InferVars<vars>
+  /** The CLI version string. */
+  version: string | undefined
+}) =>
+  | InferReturn<output>
+  | Promise<InferReturn<output>>
+  | AsyncGenerator<InferReturn<output>, unknown, unknown>
 
 /** @internal A formatted CTA block as it appears in the output envelope. */
 type FormattedCtaBlock = {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -54,7 +54,7 @@ export type Cli<
       name: name,
       definition: CommandDefinition<args, cmdEnv, options, output, vars, env>,
     ): Cli<
-      commands & { [key in name]: { args: InferOutput<args>; options: InferOutput<options> } },
+      commands & { [key in name]: CommandMapEntry<args, options, output> },
       vars,
       env
     >
@@ -69,19 +69,26 @@ export type Cli<
       const opts extends z.ZodObject<any> | undefined,
     >(
       cli: Root<args, opts> & { name: name },
-    ): Cli<
-      commands & { [key in name]: { args: InferOutput<args>; options: InferOutput<opts> } },
-      vars,
-      env
-    >
-    /** Mounts a fetch handler as a command, optionally with OpenAPI spec for typed subcommands. */
+    ): Cli<commands & { [key in name]: CommandMapEntry<args, opts> }, vars, env>
+    /** Mounts a fetch handler with an OpenAPI spec as a typed command group. */
+    <const name extends string, const spec extends Openapi.OpenAPISpec>(
+      name: name,
+      definition: {
+        basePath?: string | undefined
+        description?: string | undefined
+        fetch: FetchHandler
+        openapi: spec
+        outputPolicy?: OutputPolicy | undefined
+      },
+    ): Cli<commands & Openapi.CommandMap<name, spec>, vars, env>
+    /** Mounts a raw fetch handler as an untyped command gateway. */
     <const name extends string>(
       name: name,
       definition: {
         basePath?: string | undefined
         description?: string | undefined
         fetch: FetchHandler
-        openapi?: Openapi.OpenAPISpec | undefined
+        openapi?: undefined
         outputPolicy?: OutputPolicy | undefined
       },
     ): Cli<commands, vars, env>
@@ -165,7 +172,7 @@ export function create<
 >(
   name: string,
   definition: create.Options<args, env, opts, output, vars> & { run: Function },
-): Cli<{ [key in typeof name]: { args: InferOutput<args>; options: InferOutput<opts> } }, vars, env>
+): Cli<{ [key in typeof name]: CommandMapEntry<args, opts, output> }, vars, env>
 /** Creates a router CLI that registers subcommands. */
 export function create<
   const args extends z.ZodObject<any> | undefined = undefined,
@@ -185,7 +192,7 @@ export function create<
   definition: create.Options<args, env, opts, output, vars> & { name: string; run: Function },
 ): Cli<
   {
-    [key in (typeof definition)['name']]: { args: InferOutput<args>; options: InferOutput<opts> }
+    [key in (typeof definition)['name']]: CommandMapEntry<args, opts, output>
   },
   vars,
   env
@@ -209,7 +216,6 @@ export function create(
 
   const commands = new Map<string, CommandEntry>()
   const middlewares: MiddlewareHandler[] = []
-  const pending: Promise<void>[] = []
   const mcpHandler = createMcpHttpHandler(name, def.version ?? '0.0.0')
 
   const cli: Cli = {
@@ -221,20 +227,17 @@ export function create(
     command(nameOrCli: any, def?: any): any {
       if (typeof nameOrCli === 'string') {
         if (def && 'fetch' in def && typeof def.fetch === 'function') {
-          // OpenAPI + fetch → generate typed command group (async, resolved before serve)
+          // OpenAPI + fetch → generate typed command group.
           if (def.openapi) {
-            pending.push(
-              Openapi.generateCommands(def.openapi, def.fetch, { basePath: def.basePath }).then(
-                (generated) => {
-                  commands.set(nameOrCli, {
-                    _group: true,
-                    description: def.description,
-                    commands: generated as Map<string, CommandEntry>,
-                    ...(def.outputPolicy ? { outputPolicy: def.outputPolicy } : undefined),
-                  } as InternalGroup)
-                },
-              ),
-            )
+            const generated = Openapi.generateCommands(def.openapi, def.fetch, {
+              basePath: def.basePath,
+            })
+            commands.set(nameOrCli, {
+              _group: true,
+              description: def.description,
+              commands: generated as Map<string, CommandEntry>,
+              ...(def.outputPolicy ? { outputPolicy: def.outputPolicy } : undefined),
+            } as InternalGroup)
             return cli
           }
           commands.set(nameOrCli, {
@@ -274,7 +277,6 @@ export function create(
     },
 
     async fetch(req: Request) {
-      if (pending.length > 0) await Promise.all(pending)
       return fetchImpl(name, commands, req, {
         description: def.description,
         envSchema: def.env,
@@ -288,7 +290,6 @@ export function create(
     },
 
     async serve(argv = process.argv.slice(2), serveOptions: serve.Options = {}) {
-      if (pending.length > 0) await Promise.all(pending)
       return serveImpl(name, commands, argv, {
         ...serveOptions,
         aliases: def.aliases,
@@ -2481,7 +2482,14 @@ function formatFetchHelp(name: string, description?: string): string {
 /** Shape of the commands map accumulated through `.command()` chains. */
 export type CommandsMap = Record<
   string,
-  { args: Record<string, unknown>; options: Record<string, unknown> }
+  {
+    /** Command positional argument shape. */
+    args: Record<string, unknown>
+    /** Command named option shape. */
+    options: Record<string, unknown>
+    /** Command output shape. */
+    output?: unknown | undefined
+  }
 >
 
 /** @internal Entry stored in a command map — either a leaf definition, a group, or a fetch gateway. */
@@ -3075,6 +3083,16 @@ type InferOutput<schema extends z.ZodObject<any> | undefined> =
 type InferReturn<output extends z.ZodType | undefined> = output extends z.ZodType
   ? z.output<output>
   : unknown
+
+/** @internal Shape of a command entry inferred from command schemas. */
+type CommandMapEntry<
+  args extends z.ZodObject<any> | undefined = undefined,
+  options extends z.ZodObject<any> | undefined = undefined,
+  output extends z.ZodType | undefined = undefined,
+> = {
+  args: InferOutput<args>
+  options: InferOutput<options>
+} & (output extends z.ZodType ? { output: InferReturn<output> } : {})
 
 /** @internal Inferred vars type from a Zod schema, or `{}` when no schema is provided. */
 type InferVars<vars extends z.ZodObject<any> | undefined> =

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -159,10 +159,14 @@ export type Cta<commands extends CommandsMap = Commands> =
               }
             }[keyof commands & string]
           | {
+              /** Positional arguments appended as bare values. */
+              args?: Record<string, unknown> | undefined
               /** The command name to run. */
               command: string & {}
               /** A short description of what the command does. */
               description?: string | undefined
+              /** Named options formatted as `--key value` flags. */
+              options?: Record<string, unknown> | undefined
             })
 
 /** Creates a CLI with a root handler. Can still register subcommands which take precedence. */

--- a/src/Client.test-d.ts
+++ b/src/Client.test-d.ts
@@ -1,0 +1,291 @@
+import { Cli, createClient } from 'incur'
+import { expectTypeOf, test } from 'vitest'
+
+type GeneratedCommands = {
+  ping: {
+    args: {}
+    options: {}
+    output: { ok: boolean }
+  }
+  'project deploy': {
+    args: { id: string }
+    options: { dryRun: boolean }
+    output: { deployId: string; status: 'queued' | 'done' }
+  }
+  'project inspect': {
+    args: { id: string; includeLogs?: boolean | undefined }
+    options: {}
+    output: { id: string; logs?: string[] | undefined }
+  }
+  'project list': {
+    args: {}
+    options: { cursor?: string | undefined; limit?: number | undefined }
+    output: { items: string[]; nextCursor?: string | undefined }
+  }
+  'auth login': {
+    args: {}
+    options: { token: string }
+    output: void
+  }
+  'config set': {
+    args: { key: string; value: number | string }
+    options: { force: boolean; scope?: 'project' | 'user' | undefined }
+    output: { saved: true }
+  }
+  raw: {
+    args: unknown
+    options: unknown
+    output: unknown
+  }
+}
+
+test('createClient selects args, options, and output by command string', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const deploy = client('project deploy')
+
+  expectTypeOf<Parameters<typeof deploy>[0]>().toExtend<{
+    args: { id: string }
+    options: { dryRun: boolean }
+  }>()
+  expectTypeOf<{
+    args: { id: string }
+    options: { dryRun: boolean }
+  }>().toExtend<Parameters<typeof deploy>[0]>()
+  expectTypeOf<Awaited<ReturnType<typeof deploy>>>().toEqualTypeOf<{
+    deployId: string
+    status: 'queued' | 'done'
+  }>()
+
+  deploy({ args: { id: 'p1' }, options: { dryRun: true } })
+
+  // @ts-expect-error missing required args
+  deploy({ options: { dryRun: true } })
+
+  // @ts-expect-error missing required options
+  deploy({ args: { id: 'p1' } })
+
+  // @ts-expect-error arg property has the wrong type
+  deploy({ args: { id: 1 }, options: { dryRun: true } })
+
+  // @ts-expect-error unknown option property
+  deploy({ args: { id: 'p1' }, options: { dryRun: true, verbose: true } })
+
+  // @ts-expect-error unknown command
+  client('project destroy')
+})
+
+test('createClient allows omitted input when args and options are empty', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const ping = client('ping')
+
+  expectTypeOf<Awaited<ReturnType<typeof ping>>>().toEqualTypeOf<{ ok: boolean }>()
+  ping()
+  ping({})
+  ping({ args: {}, options: {} })
+})
+
+test('createClient requires input when args are required and options are empty', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const inspect = client('project inspect')
+
+  type Input = {
+    args: { id: string; includeLogs?: boolean | undefined }
+    options?: {} | undefined
+  }
+  expectTypeOf<Parameters<typeof inspect>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof inspect>[0]>()
+  expectTypeOf<Awaited<ReturnType<typeof inspect>>>().toEqualTypeOf<{
+    id: string
+    logs?: string[] | undefined
+  }>()
+
+  inspect({ args: { id: 'p1' } })
+  inspect({ args: { id: 'p1', includeLogs: true }, options: {} })
+
+  // @ts-expect-error input is required when args has a required key
+  inspect()
+
+  // @ts-expect-error required arg key is missing
+  inspect({ args: {} })
+})
+
+test('createClient allows optional input when args and options have no required keys', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const list = client('project list')
+
+  type Input =
+    | {
+        args?: {} | undefined
+        options?: { cursor?: string | undefined; limit?: number | undefined } | undefined
+      }
+    | undefined
+  expectTypeOf<Parameters<typeof list>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof list>[0]>()
+
+  list()
+  list({})
+  list({ options: { limit: 10 } })
+  list({ args: {}, options: { cursor: 'next' } })
+
+  // @ts-expect-error optional option has the wrong type
+  list({ options: { limit: '10' } })
+})
+
+test('createClient requires input when only options are required', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const login = client('auth login')
+
+  type Input = {
+    args?: {} | undefined
+    options: { token: string }
+  }
+  expectTypeOf<Parameters<typeof login>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof login>[0]>()
+
+  login({ options: { token: 'secret' } })
+  login({ args: {}, options: { token: 'secret' } })
+
+  // @ts-expect-error options are required
+  login()
+
+  // @ts-expect-error required option key is missing
+  login({ options: {} })
+})
+
+test('createClient preserves mixed required and optional fields', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const set = client('config set')
+
+  type Input = {
+    args: { key: string; value: number | string }
+    options: { force: boolean; scope?: 'project' | 'user' | undefined }
+  }
+  expectTypeOf<Parameters<typeof set>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof set>[0]>()
+
+  set({ args: { key: 'theme', value: 'dark' }, options: { force: false } })
+  set({ args: { key: 'retries', value: 3 }, options: { force: true, scope: 'user' } })
+
+  // @ts-expect-error optional option still narrows to known values
+  set({ args: { key: 'theme', value: 'dark' }, options: { force: true, scope: 'org' } })
+})
+
+test('createClient keeps unknown args, options, and output unknown', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const raw = client('raw')
+
+  type Input = { args?: unknown; options?: unknown } | undefined
+  expectTypeOf<Parameters<typeof raw>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof raw>[0]>()
+  expectTypeOf<Awaited<ReturnType<typeof raw>>>().toEqualTypeOf<unknown>()
+
+  raw()
+  raw({ args: 'anything', options: 123 })
+})
+
+test('createClient defaults to a permissive unknown command map without registration', () => {
+  const client = createClient({ baseUrl: 'https://api.example.com' })
+  const call = client('anything')
+
+  type Input = { args?: unknown; options?: unknown } | undefined
+  expectTypeOf<Parameters<typeof call>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof call>[0]>()
+  expectTypeOf<Awaited<ReturnType<typeof call>>>().toEqualTypeOf<unknown>()
+
+  call()
+  call({ args: { any: 'value' }, options: ['also accepted'] })
+})
+
+test('generated command map preserves exact optional properties', () => {
+  expectTypeOf<GeneratedCommands['project list']['options']>().toEqualTypeOf<{
+    cursor?: string | undefined
+    limit?: number | undefined
+  }>()
+  expectTypeOf<GeneratedCommands['project list']['output']>().toEqualTypeOf<{
+    items: string[]
+    nextCursor?: string | undefined
+  }>()
+})
+
+test('generated command map works with required input and output inference', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const deploy = client('project deploy')
+
+  type Input = {
+    args: { id: string }
+    options: { dryRun: boolean }
+  }
+  expectTypeOf<Parameters<typeof deploy>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof deploy>[0]>()
+  expectTypeOf<Awaited<ReturnType<typeof deploy>>>().toEqualTypeOf<{
+    deployId: string
+    status: 'queued' | 'done'
+  }>()
+})
+
+test('generated command map allows optional input with explicit undefined values', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const list = client('project list')
+
+  list({ options: { cursor: undefined, limit: undefined } })
+})
+
+test('createClient consumes OpenAPI mounted command maps inferred from Cli instances', () => {
+  const spec = {
+    openapi: '3.0.0',
+    info: { title: 'Test', version: '1.0.0' },
+    paths: {
+      '/users/{id}': {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'number' },
+          },
+        ],
+        get: {
+          operationId: 'getUser',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { id: { type: 'number' }, name: { type: 'string' } },
+                    required: ['id', 'name'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  } as const
+  const cli = Cli.create('test').command('api', {
+    fetch: () => new Response(),
+    openapi: spec,
+  })
+  type Commands = typeof cli extends Cli.Cli<infer commands> ? commands : never
+  const client = createClient<Commands>({ baseUrl: 'https://api.example.com' })
+  const getUser = client('api getUser')
+
+  expectTypeOf<Parameters<typeof getUser>[0]>().toExtend<{
+    args: { id: number }
+    options?: {} | undefined
+  }>()
+  expectTypeOf<Awaited<ReturnType<typeof getUser>>>().toExtend<{
+    id: number
+    name: string
+  }>()
+
+  getUser({ args: { id: 1 } })
+
+  // @ts-expect-error OpenAPI path args are required
+  getUser()
+
+  // @ts-expect-error raw fetch gateway is not generated as a command
+  client('api')
+})

--- a/src/Client.test-d.ts
+++ b/src/Client.test-d.ts
@@ -19,6 +19,13 @@ export type Commands = {
   }
   /** Generated command "auth". */
   auth: { args: {}; options: { token: string }; output: void }
+  /** Generated command "logs". */
+  logs: {
+    args: {}
+    options: {}
+    output: { line: string }
+    stream: true
+  }
   /** Generated command "project deploy". */
   'project deploy': {
     args: { id: string }
@@ -208,6 +215,19 @@ test('createClient can be made permissive with an explicit unknown command map',
 
   call()
   call({ args: { any: 'value' }, options: ['also accepted'] })
+})
+
+test('createClient returns async iterables for streaming commands', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const logs = client('logs')
+
+  expectTypeOf<Awaited<ReturnType<typeof logs>>>().toEqualTypeOf<AsyncIterable<{ line: string }>>()
+
+  async function read() {
+    const stream = await logs()
+    for await (const chunk of stream) expectTypeOf(chunk).toEqualTypeOf<{ line: string }>()
+  }
+  void read
 })
 
 test('ClientError can be imported and RPC payloads can be narrowed', () => {

--- a/src/Client.test-d.ts
+++ b/src/Client.test-d.ts
@@ -2,43 +2,53 @@ import { Cli, ClientError, createClient, isClientRpcError, isClientRpcErrorEnvel
 import type { ClientRpcError, ClientRpcErrorEnvelope } from 'incur'
 import { expectTypeOf, test } from 'vitest'
 
-type GeneratedCommands = {
-  ping: {
-    args: {}
-    options: {}
-    output: { ok: boolean }
+// BEGIN generated client round-trip fixture
+/** Command map generated from your incur CLI. */
+export type Commands = {
+  /** Generated command "admin users get". */
+  'admin users get': {
+    args: { id: number }
+    options: { verbose?: boolean | undefined }
+    output: { id: number }
   }
+  /** Generated command "api getUser". */
+  'api getUser': {
+    args: { id: number }
+    options: {}
+    output: { id: number; name: string; [key: string]: unknown }
+  }
+  /** Generated command "auth". */
+  auth: { args: {}; options: { token: string }; output: void }
+  /** Generated command "project deploy". */
   'project deploy': {
     args: { id: string }
     options: { dryRun: boolean }
     output: { deployId: string; status: 'queued' | 'done' }
   }
+  /** Generated command "project inspect". */
   'project inspect': {
     args: { id: string; includeLogs?: boolean | undefined }
     options: {}
     output: { id: string; logs?: string[] | undefined }
   }
+  /** Generated command "project list". */
   'project list': {
     args: {}
     options: { cursor?: string | undefined; limit?: number | undefined }
     output: { items: string[]; nextCursor?: string | undefined }
   }
-  'auth login': {
-    args: {}
-    options: { token: string }
-    output: void
-  }
-  'config set': {
-    args: { key: string; value: number | string }
-    options: { force: boolean; scope?: 'project' | 'user' | undefined }
-    output: { saved: true }
-  }
-  raw: {
-    args: unknown
-    options: unknown
-    output: unknown
+  /** Generated command "status". */
+  status: { args: {}; options: {}; output: { ok: boolean } }
+}
+
+declare module 'incur' {
+  interface Register {
+    commands: Commands
   }
 }
+// END generated client round-trip fixture
+
+type GeneratedCommands = Commands
 
 test('createClient selects args, options, and output by command string', () => {
   const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
@@ -77,12 +87,12 @@ test('createClient selects args, options, and output by command string', () => {
 
 test('createClient allows omitted input when args and options are empty', () => {
   const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
-  const ping = client('ping')
+  const status = client('status')
 
-  expectTypeOf<Awaited<ReturnType<typeof ping>>>().toEqualTypeOf<{ ok: boolean }>()
-  ping()
-  ping({})
-  ping({ args: {}, options: {} })
+  expectTypeOf<Awaited<ReturnType<typeof status>>>().toEqualTypeOf<{ ok: boolean }>()
+  status()
+  status({})
+  status({ args: {}, options: {} })
 })
 
 test('createClient requires input when args are required and options are empty', () => {
@@ -134,45 +144,47 @@ test('createClient allows optional input when args and options have no required 
 
 test('createClient requires input when only options are required', () => {
   const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
-  const login = client('auth login')
+  const auth = client('auth')
 
   type Input = {
     args?: {} | undefined
     options: { token: string }
   }
-  expectTypeOf<Parameters<typeof login>[0]>().toExtend<Input>()
-  expectTypeOf<Input>().toExtend<Parameters<typeof login>[0]>()
+  expectTypeOf<Parameters<typeof auth>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof auth>[0]>()
 
-  login({ options: { token: 'secret' } })
-  login({ args: {}, options: { token: 'secret' } })
+  auth({ options: { token: 'secret' } })
+  auth({ args: {}, options: { token: 'secret' } })
 
   // @ts-expect-error options are required
-  login()
+  auth()
 
   // @ts-expect-error required option key is missing
-  login({ options: {} })
+  auth({ options: {} })
 })
 
-test('createClient preserves mixed required and optional fields', () => {
+test('createClient preserves mounted sub-CLI groups', () => {
   const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
-  const set = client('config set')
+  const get = client('admin users get')
 
   type Input = {
-    args: { key: string; value: number | string }
-    options: { force: boolean; scope?: 'project' | 'user' | undefined }
+    args: { id: number }
+    options?: { verbose?: boolean | undefined } | undefined
   }
-  expectTypeOf<Parameters<typeof set>[0]>().toExtend<Input>()
-  expectTypeOf<Input>().toExtend<Parameters<typeof set>[0]>()
+  expectTypeOf<Parameters<typeof get>[0]>().toExtend<Input>()
+  expectTypeOf<Input>().toExtend<Parameters<typeof get>[0]>()
+  expectTypeOf<Awaited<ReturnType<typeof get>>>().toEqualTypeOf<{ id: number }>()
 
-  set({ args: { key: 'theme', value: 'dark' }, options: { force: false } })
-  set({ args: { key: 'retries', value: 3 }, options: { force: true, scope: 'user' } })
+  get({ args: { id: 1 } })
+  get({ args: { id: 1 }, options: { verbose: true } })
 
-  // @ts-expect-error optional option still narrows to known values
-  set({ args: { key: 'theme', value: 'dark' }, options: { force: true, scope: 'org' } })
+  // @ts-expect-error mounted sub-CLI args keep their generated types
+  get({ args: { id: '1' } })
 })
 
 test('createClient keeps unknown args, options, and output unknown', () => {
-  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  type RuntimeCommands = Record<string, { args: unknown; options: unknown; output: unknown }>
+  const client = createClient<RuntimeCommands>({ baseUrl: 'https://api.example.com' })
   const raw = client('raw')
 
   type Input = { args?: unknown; options?: unknown } | undefined
@@ -184,8 +196,9 @@ test('createClient keeps unknown args, options, and output unknown', () => {
   raw({ args: 'anything', options: 123 })
 })
 
-test('createClient defaults to a permissive unknown command map without registration', () => {
-  const client = createClient({ baseUrl: 'https://api.example.com' })
+test('createClient can be made permissive with an explicit unknown command map', () => {
+  type RuntimeCommands = Record<string, { args: unknown; options: unknown; output: unknown }>
+  const client = createClient<RuntimeCommands>({ baseUrl: 'https://api.example.com' })
   const call = client('anything')
 
   type Input = { args?: unknown; options?: unknown } | undefined
@@ -268,6 +281,17 @@ test('generated command map allows optional input with explicit undefined values
   const list = client('project list')
 
   list({ options: { cursor: undefined, limit: undefined } })
+})
+
+test('generated command map includes mounted root CLIs and omits aliases', () => {
+  const client = createClient<GeneratedCommands>({ baseUrl: 'https://api.example.com' })
+  const status = client('status')
+
+  expectTypeOf<Awaited<ReturnType<typeof status>>>().toEqualTypeOf<{ ok: boolean }>()
+  status()
+
+  // @ts-expect-error aliases are intentionally absent from generated command maps
+  client('ship')
 })
 
 test('createClient consumes OpenAPI mounted command maps inferred from Cli instances', () => {

--- a/src/Client.test-d.ts
+++ b/src/Client.test-d.ts
@@ -1,4 +1,5 @@
-import { Cli, createClient } from 'incur'
+import { Cli, ClientError, createClient, isClientRpcError, isClientRpcErrorEnvelope } from 'incur'
+import type { ClientRpcError, ClientRpcErrorEnvelope } from 'incur'
 import { expectTypeOf, test } from 'vitest'
 
 type GeneratedCommands = {
@@ -194,6 +195,45 @@ test('createClient defaults to a permissive unknown command map without registra
 
   call()
   call({ args: { any: 'value' }, options: ['also accepted'] })
+})
+
+test('ClientError can be imported and RPC payloads can be narrowed', () => {
+  const error = new ClientError('Invalid input', {
+    error: {
+      code: 'VALIDATION_ERROR',
+      message: 'Invalid input',
+      retryable: false,
+      fieldErrors: [
+        {
+          path: 'id',
+          expected: 'string',
+          received: 'number',
+          message: 'Expected string, received number',
+        },
+      ],
+    } satisfies ClientRpcError,
+    status: 400,
+  })
+  const caught: unknown = error
+
+  if (caught instanceof ClientError) {
+    expectTypeOf(caught.data).toEqualTypeOf<unknown>()
+    expectTypeOf(caught.error).toEqualTypeOf<unknown>()
+    expectTypeOf(caught.status).toEqualTypeOf<number | undefined>()
+
+    if (isClientRpcError(caught.error)) {
+      expectTypeOf(caught.error).toEqualTypeOf<ClientRpcError>()
+      expectTypeOf(caught.error.code).toEqualTypeOf<string>()
+      expectTypeOf(caught.error.retryable).toEqualTypeOf<boolean | undefined>()
+      expectTypeOf(caught.error.fieldErrors?.[0]?.path).toEqualTypeOf<string | undefined>()
+    }
+
+    if (isClientRpcErrorEnvelope(caught.data)) {
+      expectTypeOf(caught.data).toEqualTypeOf<ClientRpcErrorEnvelope>()
+      expectTypeOf(caught.data.error.code).toEqualTypeOf<string>()
+      expectTypeOf(caught.data.meta?.command).toEqualTypeOf<string | undefined>()
+    }
+  }
 })
 
 test('generated command map preserves exact optional properties', () => {

--- a/src/Client.test.ts
+++ b/src/Client.test.ts
@@ -1,4 +1,11 @@
-import { ClientError, createClient, isClientRpcError, isClientRpcErrorEnvelope } from 'incur'
+import {
+  Cli,
+  ClientError,
+  createClient,
+  isClientRpcError,
+  isClientRpcErrorEnvelope,
+  z,
+} from 'incur'
 
 type RuntimeCommands = Record<string, { args: unknown; options: unknown; output: unknown }>
 
@@ -28,7 +35,7 @@ describe('createClient', () => {
     expect(calls[0]?.url).toBe('https://api.example.com/_incur/rpc')
     expect(calls[0]?.init?.method).toBe('POST')
     expect(calls[0]?.init?.headers).toEqual({
-      accept: 'application/json',
+      accept: 'application/json, application/x-ndjson',
       'content-type': 'application/json',
     })
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
@@ -157,6 +164,278 @@ describe('createClient', () => {
         expect(error.data.meta?.command).toBe('project deploy')
       }
     }
+  })
+
+  test('returns async iterable for streaming RPC responses', async () => {
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response(
+          [
+            JSON.stringify({ type: 'chunk', data: { line: 'one' } }),
+            JSON.stringify({ type: 'chunk', data: { line: 'two' } }),
+            JSON.stringify({ type: 'done', ok: true, meta: { command: 'logs' } }),
+          ].join('\n') + '\n',
+          { headers: { 'content-type': 'application/x-ndjson' } },
+        ),
+    })
+
+    const stream = await client('logs')()
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+
+    expect(chunks).toEqual([{ line: 'one' }, { line: 'two' }])
+  })
+
+  test('calls a real CLI RPC server and unwraps non-streaming responses', async () => {
+    const cli = Cli.create('test').command('sum', {
+      args: z.object({ left: z.number() }),
+      options: z.object({ right: z.number() }),
+      run: (c) => ({ value: c.args.left + c.options.right }),
+    })
+    const client = createClient<{
+      sum: { args: { left: number }; options: { right: number }; output: { value: number } }
+    }>({
+      baseUrl: 'http://localhost',
+      fetch: (input, init) => cli.fetch(new Request(input, init)),
+    })
+
+    await expect(
+      client('sum')({
+        args: { left: 1 },
+        options: { right: 2 },
+      }),
+    ).resolves.toEqual({ value: 3 })
+  })
+
+  test('calls a real CLI RPC server and iterates streaming responses', async () => {
+    const cli = Cli.create('test').command('logs', {
+      args: z.object({ prefix: z.string() }),
+      options: z.object({ count: z.number() }),
+      output: z.object({ line: z.string() }),
+      async *run(c) {
+        yield { line: `${c.args.prefix}-1` }
+        yield { line: `${c.args.prefix}-${c.options.count}` }
+      },
+    })
+    const client = createClient<{
+      logs: {
+        args: { prefix: string }
+        options: { count: number }
+        output: { line: string }
+        stream: true
+      }
+    }>({
+      baseUrl: 'http://localhost',
+      fetch: (input, init) => cli.fetch(new Request(input, init)),
+    })
+
+    const stream = await client('logs')({
+      args: { prefix: 'line' },
+      options: { count: 2 },
+    })
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+
+    expect(chunks).toEqual([{ line: 'line-1' }, { line: 'line-2' }])
+  })
+
+  test('throws failed streaming RPC records', async () => {
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            type: 'error',
+            ok: false,
+            error: { code: 'NOPE', message: 'Nope' },
+          }) + '\n',
+          { headers: { 'content-type': 'application/x-ndjson' }, status: 500 },
+        ),
+    })
+
+    const stream = await client('logs')()
+    await expect(async () => {
+      for await (const chunk of stream) void chunk
+    }).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'Nope',
+      error: { code: 'NOPE', message: 'Nope' },
+      status: 500,
+    })
+  })
+
+  test('throws invalid JSON streaming RPC records', async () => {
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response('{bad json}\n', {
+          headers: { 'content-type': 'application/x-ndjson' },
+          status: 502,
+        }),
+    })
+
+    const stream = await client('logs')()
+    await expect(async () => {
+      for await (const chunk of stream) void chunk
+    }).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'Expected a JSON RPC stream record',
+      data: '{bad json}',
+      status: 502,
+    })
+  })
+
+  test('parses streaming RPC records split across chunks', async () => {
+    const encoder = new TextEncoder()
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"type":"chunk","data":{"line":"'))
+        controller.enqueue(encoder.encode('one"}}\n{"type":"chunk","data":{"line":"two"}}\n'))
+        controller.enqueue(encoder.encode('{"type":"done","ok":true}\n'))
+        controller.close()
+      },
+    })
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response(body, {
+          headers: { 'content-type': 'application/x-ndjson' },
+        }),
+    })
+
+    const stream = await client('logs')()
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+
+    expect(chunks).toEqual([{ line: 'one' }, { line: 'two' }])
+  })
+
+  test('ignores blank lines in streaming RPC responses', async () => {
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response(
+          [
+            '',
+            '  ',
+            JSON.stringify({ type: 'chunk', data: { line: 'one' } }),
+            '',
+            JSON.stringify({ type: 'done', ok: true }),
+          ].join('\n') + '\n',
+          { headers: { 'content-type': 'application/x-ndjson' } },
+        ),
+    })
+
+    const stream = await client('logs')()
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+
+    expect(chunks).toEqual([{ line: 'one' }])
+  })
+
+  test('throws when streaming RPC responses have no body', async () => {
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response(null, {
+          headers: { 'content-type': 'application/x-ndjson' },
+          status: 204,
+        }),
+    })
+
+    const stream = await client('logs')()
+    await expect(async () => {
+      for await (const chunk of stream) void chunk
+    }).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'Expected an RPC stream body',
+      status: 204,
+    })
+  })
+
+  test('throws malformed streaming RPC records', async () => {
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response(JSON.stringify({ type: 'done', ok: false }) + '\n', {
+          headers: { 'content-type': 'application/x-ndjson' },
+        }),
+    })
+
+    const stream = await client('logs')()
+    await expect(async () => {
+      for await (const chunk of stream) void chunk
+    }).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'Malformed RPC stream record',
+      data: { type: 'done', ok: false },
+    })
+  })
+
+  test('throws when streaming RPC responses end before done', async () => {
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response(JSON.stringify({ type: 'chunk', data: { line: 'one' } }) + '\n', {
+          headers: { 'content-type': 'application/x-ndjson' },
+        }),
+    })
+
+    const stream = await client('logs')()
+    await expect(async () => {
+      for await (const chunk of stream) void chunk
+    }).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'RPC stream ended before done',
+    })
+  })
+
+  test('cancels streaming RPC responses when consumers stop early', async () => {
+    let cancelled = false
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(JSON.stringify({ type: 'chunk', data: { line: 'one' } }) + '\n'),
+        )
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+    const client = createClient<{
+      logs: { args: {}; options: {}; output: { line: string }; stream: true }
+    }>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        new Response(body, {
+          headers: { 'content-type': 'application/x-ndjson' },
+        }),
+    })
+
+    const stream = await client('logs')()
+    for await (const chunk of stream) {
+      void chunk
+      break
+    }
+
+    expect(cancelled).toBe(true)
   })
 
   test('uses a fallback message for failed RPC envelopes without error messages', async () => {

--- a/src/Client.test.ts
+++ b/src/Client.test.ts
@@ -1,0 +1,179 @@
+import { createClient } from 'incur'
+
+type RuntimeCommands = Record<string, { args: unknown; options: unknown; output: unknown }>
+
+describe('createClient', () => {
+  test('posts command calls to the RPC route and unwraps ok data', async () => {
+    const calls: { init: RequestInit | undefined; url: string }[] = []
+    const client = createClient<RuntimeCommands>({
+      baseUrl: 'https://api.example.com',
+      fetch: async (input, init) => {
+        calls.push({ init, url: String(input) })
+        return Response.json({
+          ok: true,
+          data: { deployId: 'd1', status: 'queued' },
+          meta: { command: 'project deploy', duration: '1ms' },
+        })
+      },
+    })
+
+    await expect(
+      client('project deploy')({
+        args: { id: 'p1' },
+        options: { dryRun: true },
+      }),
+    ).resolves.toEqual({ deployId: 'd1', status: 'queued' })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe('https://api.example.com/_incur/rpc')
+    expect(calls[0]?.init?.method).toBe('POST')
+    expect(calls[0]?.init?.headers).toEqual({
+      accept: 'application/json',
+      'content-type': 'application/json',
+    })
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
+      command: 'project deploy',
+      args: { id: 'p1' },
+      options: { dryRun: true },
+    })
+  })
+
+  test('normalizes base URL paths and URL instances', async () => {
+    const urls: string[] = []
+    const fetch = async (input: RequestInfo | URL) => {
+      urls.push(String(input))
+      return Response.json({ ok: true, data: null })
+    }
+
+    await createClient<RuntimeCommands>({ baseUrl: 'https://api.example.com/v1', fetch })('ping')()
+    await createClient<RuntimeCommands>({ baseUrl: 'https://api.example.com/v1/', fetch })('ping')()
+    await createClient<RuntimeCommands>({ baseUrl: new URL('https://api.example.com/v2'), fetch })(
+      'ping',
+    )()
+
+    expect(urls).toEqual([
+      'https://api.example.com/v1/_incur/rpc',
+      'https://api.example.com/v1/_incur/rpc',
+      'https://api.example.com/v2/_incur/rpc',
+    ])
+  })
+
+  test('defaults omitted args and options to empty objects', async () => {
+    const bodies: unknown[] = []
+    const client = createClient<RuntimeCommands>({
+      baseUrl: 'https://api.example.com',
+      fetch: async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)))
+        return Response.json({ ok: true, data: 'pong' })
+      },
+    })
+
+    await client('ping')()
+    await client('ping')({ args: { id: 'p1' } })
+    await client('ping')({ options: { dryRun: true } })
+
+    expect(bodies).toEqual([
+      { command: 'ping', args: {}, options: {} },
+      { command: 'ping', args: { id: 'p1' }, options: {} },
+      { command: 'ping', args: {}, options: { dryRun: true } },
+    ])
+  })
+
+  test('throws failed RPC envelopes', async () => {
+    const client = createClient<RuntimeCommands>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        Response.json(
+          {
+            ok: false,
+            error: { code: 'NOPE', message: 'Nope' },
+            meta: { command: 'project deploy', duration: '1ms' },
+          },
+          { status: 500 },
+        ),
+    })
+
+    await expect(
+      client('project deploy')({
+        args: { id: 'p1' },
+        options: { dryRun: true },
+      }),
+    ).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'Nope',
+      error: { code: 'NOPE', message: 'Nope' },
+      status: 500,
+    })
+  })
+
+  test('uses a fallback message for failed RPC envelopes without error messages', async () => {
+    const client = createClient<RuntimeCommands>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () => Response.json({ ok: false, error: 'NOPE' }, { status: 400 }),
+    })
+
+    await expect(client('project deploy')()).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'RPC command failed',
+      data: { ok: false, error: 'NOPE' },
+      error: 'NOPE',
+      status: 400,
+    })
+  })
+
+  test('wraps fetch failures', async () => {
+    const cause = new Error('network down')
+    const client = createClient<RuntimeCommands>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () => {
+        throw cause
+      },
+    })
+
+    await expect(client('ping')()).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'RPC request failed',
+      cause,
+    })
+  })
+
+  test('throws for non-json responses', async () => {
+    const client = createClient<RuntimeCommands>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () => new Response('not json', { status: 502 }),
+    })
+
+    await expect(client('ping')()).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'Expected a JSON RPC envelope',
+      data: 'not json',
+      status: 502,
+    })
+  })
+
+  test('throws for malformed RPC envelopes', async () => {
+    const client = createClient<RuntimeCommands>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () => Response.json({ data: 'missing ok' }, { status: 200 }),
+    })
+
+    await expect(client('ping')()).rejects.toMatchObject({
+      name: 'Incur.ClientError',
+      message: 'Malformed RPC envelope',
+      data: { data: 'missing ok' },
+      status: 200,
+    })
+  })
+
+  test('requires fetch to exist', () => {
+    const original = globalThis.fetch
+    vi.stubGlobal('fetch', undefined)
+    try {
+      expect(() => createClient({ baseUrl: 'https://api.example.com' })).toThrow(
+        'Incur clients require a fetch implementation',
+      )
+    } finally {
+      vi.stubGlobal('fetch', original)
+    }
+  })
+})

--- a/src/Client.test.ts
+++ b/src/Client.test.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'incur'
+import { ClientError, createClient, isClientRpcError, isClientRpcErrorEnvelope } from 'incur'
 
 type RuntimeCommands = Record<string, { args: unknown; options: unknown; output: unknown }>
 
@@ -104,6 +104,59 @@ describe('createClient', () => {
       error: { code: 'NOPE', message: 'Nope' },
       status: 500,
     })
+  })
+
+  test('throws exported ClientError with narrowable RPC fields', async () => {
+    const fieldErrors = [
+      {
+        code: 'invalid_type',
+        missing: false,
+        path: 'id',
+        expected: 'string',
+        received: 'number',
+        message: 'Expected string, received number',
+      },
+    ]
+    const client = createClient<RuntimeCommands>({
+      baseUrl: 'https://api.example.com',
+      fetch: async () =>
+        Response.json(
+          {
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'Invalid input',
+              retryable: false,
+              fieldErrors,
+            },
+            meta: { command: 'project deploy', duration: '2ms' },
+          },
+          { status: 400 },
+        ),
+    })
+
+    await expect(client('project deploy')()).rejects.toBeInstanceOf(ClientError)
+
+    try {
+      await client('project deploy')()
+      throw new Error('Expected client call to fail')
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      if (!(error instanceof ClientError)) throw error
+
+      expect(error.status).toBe(400)
+      expect(isClientRpcError(error.error)).toBe(true)
+      if (isClientRpcError(error.error)) {
+        expect(error.error.code).toBe('VALIDATION_ERROR')
+        expect(error.error.retryable).toBe(false)
+        expect(error.error.fieldErrors).toEqual(fieldErrors)
+      }
+      expect(isClientRpcErrorEnvelope(error.data)).toBe(true)
+      if (isClientRpcErrorEnvelope(error.data)) {
+        expect(error.data.error.code).toBe('VALIDATION_ERROR')
+        expect(error.data.meta?.command).toBe('project deploy')
+      }
+    }
   })
 
   test('uses a fallback message for failed RPC envelopes without error messages', async () => {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,5 +1,6 @@
-import type { Register } from './Register.js'
+import { ClientError } from './Errors.js'
 import { isRecord } from './internal/helpers.js'
+import type { Register } from './Register.js'
 
 type DefaultCommand = {
   args: unknown
@@ -58,37 +59,6 @@ type ClientOptions = {
   baseUrl: string | URL
   /** Fetch implementation. Defaults to `globalThis.fetch`. */
   fetch?: typeof globalThis.fetch | undefined
-}
-
-/** Options for constructing a client error. */
-type ClientErrorOptions = {
-  /** The underlying cause. */
-  cause?: unknown | undefined
-  /** Malformed response payload or failed RPC envelope. */
-  data?: unknown | undefined
-  /** Failed RPC error payload. */
-  error?: unknown | undefined
-  /** HTTP status returned by the server. */
-  status?: number | undefined
-}
-
-/** Error thrown by incur RPC clients. */
-class ClientError extends Error {
-  /** Error class name. */
-  override name = 'Incur.ClientError'
-  /** Malformed response payload or failed RPC envelope. */
-  data: unknown
-  /** Failed RPC error payload. */
-  error: unknown
-  /** HTTP status returned by the server. */
-  status: number | undefined
-
-  constructor(message: string, options: ClientErrorOptions = {}) {
-    super(message, 'cause' in options ? { cause: options.cause } : undefined)
-    this.data = options.data
-    this.error = options.error
-    this.status = options.status
-  }
 }
 
 /** Creates a typed incur RPC client. */

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -29,11 +29,14 @@ type Field<key extends string, value> = value extends object
   : { [field in key]?: value | undefined }
 
 type Input<command> = Field<'args', Args<command>> & Field<'options', Options<command>>
+type Result<command> = command extends { stream: true }
+  ? AsyncIterable<Output<command>>
+  : Output<command>
 
 type Caller<command> =
   RequiredKeys<Input<command>> extends never
-    ? (input?: Input<command>) => Promise<Output<command>>
-    : (input: Input<command>) => Promise<Output<command>>
+    ? (input?: Input<command>) => Promise<Result<command>>
+    : (input: Input<command>) => Promise<Result<command>>
 
 type RuntimeInput = {
   args?: unknown | undefined
@@ -77,7 +80,7 @@ export function createClient<const commands = Commands>(options: ClientOptions):
             options: input.options ?? {},
           }),
           headers: {
-            accept: 'application/json',
+            accept: 'application/json, application/x-ndjson',
             'content-type': 'application/json',
           },
           method: 'POST',
@@ -86,13 +89,12 @@ export function createClient<const commands = Commands>(options: ClientOptions):
         throw new ClientError('RPC request failed', { cause: error })
       }
 
+      if (isStreamingResponse(response)) return parseStreamingResponse(response)
+
       const envelope = await parseResponse(response)
       if (envelope.ok) return envelope.data
 
-      const message =
-        isRecord(envelope.error) && typeof envelope.error.message === 'string'
-          ? envelope.error.message
-          : 'RPC command failed'
+      const message = errorMessage(envelope.error, 'RPC command failed')
       throw new ClientError(message, {
         data: envelope,
         error: envelope.error,
@@ -105,6 +107,10 @@ function endpoint(base: string | URL): URL {
   const url = new URL(base)
   if (!url.pathname.endsWith('/')) url.pathname += '/'
   return new URL('_incur/rpc', url)
+}
+
+function isStreamingResponse(response: Response): boolean {
+  return response.headers.get('content-type')?.includes('application/x-ndjson') ?? false
 }
 
 async function parseResponse(response: Response): Promise<Envelope> {
@@ -126,4 +132,100 @@ async function parseResponse(response: Response): Promise<Envelope> {
       status: response.status,
     })
   return value as Envelope
+}
+
+async function* parseStreamingResponse(response: Response): AsyncGenerator<unknown, void, unknown> {
+  if (!response.body)
+    throw new ClientError('Expected an RPC stream body', {
+      status: response.status,
+    })
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let completed = false
+  let eof = false
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) {
+        eof = true
+        break
+      }
+      buffer += decoder.decode(value, { stream: true })
+
+      let newline: number
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline).trim()
+        buffer = buffer.slice(newline + 1)
+        if (line) {
+          const result = readStreamRecord(line, response.status)
+          if (result.done) {
+            completed = true
+            return
+          }
+          yield result.data
+        }
+      }
+    }
+
+    const remaining = buffer.trim()
+    if (remaining) {
+      const result = readStreamRecord(remaining, response.status)
+      if (result.done) {
+        completed = true
+        return
+      }
+      yield result.data
+    }
+  } finally {
+    if (!completed && !eof) await reader.cancel()
+    reader.releaseLock()
+  }
+
+  throw new ClientError('RPC stream ended before done', {
+    status: response.status,
+  })
+}
+
+function readStreamRecord(
+  line: string,
+  status: number,
+): { data: unknown; done?: false | undefined } | { done: true } {
+  let value: unknown
+  try {
+    value = JSON.parse(line)
+  } catch (error) {
+    throw new ClientError('Expected a JSON RPC stream record', {
+      cause: error,
+      data: line,
+      status,
+    })
+  }
+
+  if (!isRecord(value) || typeof value.type !== 'string')
+    throw new ClientError('Malformed RPC stream record', {
+      data: value,
+      status,
+    })
+
+  if (value.type === 'chunk') return { data: value.data }
+  if (value.type === 'done' && value.ok === true) return { done: true }
+  if (value.type === 'error' && value.ok === false) {
+    throw new ClientError(errorMessage(value.error, 'RPC stream failed'), {
+      data: value,
+      error: value.error,
+      status,
+    })
+  }
+
+  throw new ClientError('Malformed RPC stream record', {
+    data: value,
+    status,
+  })
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return isRecord(error) && typeof error.message === 'string' ? error.message : fallback
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,0 +1,159 @@
+import type { Register } from './Register.js'
+import { isRecord } from './internal/helpers.js'
+
+type DefaultCommand = {
+  args: unknown
+  options: unknown
+  output: unknown
+}
+
+type Commands = Register extends { commands: infer commands }
+  ? commands
+  : Record<string, DefaultCommand>
+
+type Args<command> = command extends { args: infer args } ? args : unknown
+type Options<command> = command extends { options: infer options } ? options : unknown
+type Output<command> = command extends { output: infer output } ? output : unknown
+
+type RequiredKeys<value> = value extends object
+  ? {
+      [key in keyof value]-?: {} extends Pick<value, key> ? never : key
+    }[keyof value]
+  : never
+
+type Field<key extends string, value> = value extends object
+  ? RequiredKeys<value> extends never
+    ? { [field in key]?: value | undefined }
+    : { [field in key]: value }
+  : { [field in key]?: value | undefined }
+
+type Input<command> = Field<'args', Args<command>> & Field<'options', Options<command>>
+
+type Caller<command> =
+  RequiredKeys<Input<command>> extends never
+    ? (input?: Input<command>) => Promise<Output<command>>
+    : (input: Input<command>) => Promise<Output<command>>
+
+type RuntimeInput = {
+  args?: unknown | undefined
+  options?: unknown | undefined
+}
+
+type Envelope = {
+  data?: unknown | undefined
+  error?: unknown | undefined
+  ok: boolean
+}
+
+/**
+ * Typed incur RPC client backed by the commands registered through declaration merging.
+ */
+export type Client<commands = Commands> = <const command extends Extract<keyof commands, string>>(
+  command: command,
+) => Caller<commands[command]>
+
+/** Options for creating an incur RPC client. */
+type ClientOptions = {
+  /** Base URL for the incur server. */
+  baseUrl: string | URL
+  /** Fetch implementation. Defaults to `globalThis.fetch`. */
+  fetch?: typeof globalThis.fetch | undefined
+}
+
+/** Options for constructing a client error. */
+type ClientErrorOptions = {
+  /** The underlying cause. */
+  cause?: unknown | undefined
+  /** Malformed response payload or failed RPC envelope. */
+  data?: unknown | undefined
+  /** Failed RPC error payload. */
+  error?: unknown | undefined
+  /** HTTP status returned by the server. */
+  status?: number | undefined
+}
+
+/** Error thrown by incur RPC clients. */
+class ClientError extends Error {
+  /** Error class name. */
+  override name = 'Incur.ClientError'
+  /** Malformed response payload or failed RPC envelope. */
+  data: unknown
+  /** Failed RPC error payload. */
+  error: unknown
+  /** HTTP status returned by the server. */
+  status: number | undefined
+
+  constructor(message: string, options: ClientErrorOptions = {}) {
+    super(message, 'cause' in options ? { cause: options.cause } : undefined)
+    this.data = options.data
+    this.error = options.error
+    this.status = options.status
+  }
+}
+
+/** Creates a typed incur RPC client. */
+export function createClient<const commands = Commands>(options: ClientOptions): Client<commands> {
+  const fetch = options.fetch ?? globalThis.fetch
+  if (!fetch) throw new ClientError('Incur clients require a fetch implementation')
+
+  return ((command: string) =>
+    async (input: RuntimeInput = {}) => {
+      let response: Response
+      try {
+        response = await fetch(endpoint(options.baseUrl), {
+          body: JSON.stringify({
+            command,
+            args: input.args ?? {},
+            options: input.options ?? {},
+          }),
+          headers: {
+            accept: 'application/json',
+            'content-type': 'application/json',
+          },
+          method: 'POST',
+        })
+      } catch (error) {
+        throw new ClientError('RPC request failed', { cause: error })
+      }
+
+      const envelope = await parseResponse(response)
+      if (envelope.ok) return envelope.data
+
+      const message =
+        isRecord(envelope.error) && typeof envelope.error.message === 'string'
+          ? envelope.error.message
+          : 'RPC command failed'
+      throw new ClientError(message, {
+        data: envelope,
+        error: envelope.error,
+        status: response.status,
+      })
+    }) as Client<commands>
+}
+
+function endpoint(base: string | URL): URL {
+  const url = new URL(base)
+  if (!url.pathname.endsWith('/')) url.pathname += '/'
+  return new URL('_incur/rpc', url)
+}
+
+async function parseResponse(response: Response): Promise<Envelope> {
+  const text = await response.text()
+  let value: unknown
+  try {
+    value = JSON.parse(text)
+  } catch (error) {
+    throw new ClientError('Expected a JSON RPC envelope', {
+      cause: error,
+      data: text,
+      status: response.status,
+    })
+  }
+
+  if (!isRecord(value) || typeof value.ok !== 'boolean')
+    throw new ClientError('Malformed RPC envelope', {
+      data: value,
+      status: response.status,
+    })
+  return value as Envelope
+}

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -87,6 +87,106 @@ export type FieldError = {
   message: string
 }
 
+/** Metadata returned with structured RPC envelopes. */
+export type ClientRpcMeta = {
+  /** Command path that handled the RPC request. */
+  command?: string | undefined
+  /** Suggested next actions returned by the command. */
+  cta?: unknown | undefined
+  /** Server-side command duration. */
+  duration?: string | undefined
+}
+
+/** Error payload returned by structured RPC commands. */
+export type ClientRpcError = {
+  /** Machine-readable error code. */
+  code: string
+  /** Human-readable error message. */
+  message: string
+  /** Whether the operation can be retried. */
+  retryable?: boolean | undefined
+  /** Per-field validation errors. */
+  fieldErrors?: FieldError[] | undefined
+}
+
+/** Successful structured RPC response envelope. */
+export type ClientRpcSuccessEnvelope = {
+  /** Command output data. */
+  data?: unknown | undefined
+  /** Response metadata. */
+  meta?: ClientRpcMeta | undefined
+  /** Whether the command succeeded. */
+  ok: true
+}
+
+/** Failed structured RPC response envelope. */
+export type ClientRpcErrorEnvelope = {
+  /** Command error payload. */
+  error: ClientRpcError
+  /** Response metadata. */
+  meta?: ClientRpcMeta | undefined
+  /** Whether the command succeeded. */
+  ok: false
+}
+
+/** Structured RPC response envelope. */
+export type ClientRpcEnvelope = ClientRpcSuccessEnvelope | ClientRpcErrorEnvelope
+
+/** Error thrown by incur RPC clients. */
+export class ClientError extends Error {
+  /** Error class name. */
+  override name = 'Incur.ClientError'
+  /** Malformed response payload or failed RPC envelope. */
+  data: unknown
+  /** Failed RPC error payload. */
+  error: unknown
+  /** HTTP status returned by the server. */
+  status: number | undefined
+
+  constructor(message: string, options: ClientError.Options = {}) {
+    super(message, 'cause' in options ? { cause: options.cause } : undefined)
+    this.data = options.data
+    this.error = options.error
+    this.status = options.status
+  }
+}
+
+export declare namespace ClientError {
+  /** Options for constructing a ClientError. */
+  type Options = {
+    /** The underlying cause. */
+    cause?: unknown | undefined
+    /** Malformed response payload or failed RPC envelope. */
+    data?: unknown | undefined
+    /** Failed RPC error payload. */
+    error?: unknown | undefined
+    /** HTTP status returned by the server. */
+    status?: number | undefined
+  }
+}
+
+/** Narrows an unknown value to a structured RPC error payload. */
+export function isClientRpcError(value: unknown): value is ClientRpcError {
+  return (
+    isErrorRecord(value) &&
+    typeof value.code === 'string' &&
+    typeof value.message === 'string' &&
+    (value.retryable === undefined || typeof value.retryable === 'boolean') &&
+    (value.fieldErrors === undefined ||
+      (Array.isArray(value.fieldErrors) && value.fieldErrors.every(isFieldError)))
+  )
+}
+
+/** Narrows an unknown value to a failed structured RPC envelope. */
+export function isClientRpcErrorEnvelope(value: unknown): value is ClientRpcErrorEnvelope {
+  return (
+    isErrorRecord(value) &&
+    value.ok === false &&
+    isClientRpcError(value.error) &&
+    (value.meta === undefined || isErrorRecord(value.meta))
+  )
+}
+
 /** Validation error with per-field error details. */
 export class ValidationError extends BaseError {
   override name = 'Incur.ValidationError'
@@ -145,4 +245,20 @@ function walk(error: unknown, fn?: ((error: unknown) => boolean) | undefined): u
   let current = error
   while ((current as any)?.cause) current = (current as any).cause
   return current
+}
+
+function isErrorRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isFieldError(value: unknown): value is FieldError {
+  return (
+    isErrorRecord(value) &&
+    (value.code === undefined || typeof value.code === 'string') &&
+    (value.missing === undefined || typeof value.missing === 'boolean') &&
+    typeof value.path === 'string' &&
+    typeof value.expected === 'string' &&
+    typeof value.received === 'string' &&
+    typeof value.message === 'string'
+  )
 }

--- a/src/Openapi.test.ts
+++ b/src/Openapi.test.ts
@@ -193,8 +193,30 @@ describe('generateCommands', () => {
       app.fetch,
     )
 
-    expect([...commands.keys()]).toEqual(['getUser'])
-    expect(commands.get('getUser')?.args?.shape.id).toBeDefined()
+    const cmd = commands.get('getUser')!
+    expect({
+      commands: [...commands.keys()],
+      args: z.toJSONSchema(cmd.args!),
+    }).toMatchInlineSnapshot(`
+      {
+        "args": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "number",
+            },
+          },
+          "required": [
+            "id",
+          ],
+          "type": "object",
+        },
+        "commands": [
+          "getUser",
+        ],
+      }
+    `)
   })
 })
 

--- a/src/Openapi.test.ts
+++ b/src/Openapi.test.ts
@@ -139,6 +139,63 @@ describe('generateCommands', () => {
     const limitSchema = cmd.options!.shape.limit
     expect(limitSchema.description).toBe('Max results')
   })
+
+  test('command has output schema from success response', async () => {
+    const commands = await Openapi.generateCommands(openapiSpec, openapiApp.fetch)
+    const cmd = commands.get('getUser')!
+    expect(cmd.output).toBeDefined()
+    expect(z.toJSONSchema(cmd.output!)).toMatchObject({
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'number' },
+        name: { type: 'string' },
+      },
+    })
+  })
+
+  test('ignores path item metadata and applies path-level parameters', async () => {
+    const commands = await Openapi.generateCommands(
+      {
+        openapi: '3.0.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/users/{id}': {
+            summary: 'User routes',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: { type: 'number' },
+              },
+            ],
+            get: {
+              operationId: 'getUser',
+              responses: {
+                200: {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: { id: { type: 'number' } },
+                        required: ['id'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      app.fetch,
+    )
+
+    expect([...commands.keys()]).toEqual(['getUser'])
+    expect(commands.get('getUser')?.args?.shape.id).toBeDefined()
+  })
 })
 
 describe('cli integration', () => {

--- a/src/Openapi.test.ts
+++ b/src/Openapi.test.ts
@@ -218,6 +218,106 @@ describe('generateCommands', () => {
       }
     `)
   })
+
+  test('supports OpenAPI 3.2 query operations', () => {
+    const commands = Openapi.generateCommands(
+      {
+        openapi: '3.2.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/search': {
+            query: {
+              operationId: 'searchUsers',
+              responses: { 200: { description: 'OK' } },
+            },
+          },
+        },
+      },
+      app.fetch,
+    )
+
+    expect(commands.has('searchUsers')).toBe(true)
+  })
+
+  test('encodes path params when building requests', async () => {
+    let url = ''
+    const commands = Openapi.generateCommands(
+      {
+        openapi: '3.0.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/files/{id}': {
+            get: {
+              operationId: 'getFile',
+              parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+              responses: { 200: { description: 'OK' } },
+            },
+          },
+        },
+      },
+      (req) => {
+        url = req.url
+        return Response.json({ ok: true })
+      },
+    )
+
+    await commands.get('getFile')!.run({ args: { id: 'a/b c' } })
+    expect(url).toBe('http://localhost/files/a%2Fb%20c')
+  })
+
+  test('coerces string false to boolean false for OpenAPI params', () => {
+    const commands = Openapi.generateCommands(
+      {
+        openapi: '3.0.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'listUsers',
+              parameters: [{ name: 'active', in: 'query', schema: { type: 'boolean' } }],
+              responses: { 200: { description: 'OK' } },
+            },
+          },
+        },
+      },
+      app.fetch,
+    )
+
+    expect(commands.get('listUsers')!.options!.parse({ active: 'false' })).toEqual({
+      active: false,
+    })
+  })
+
+  test('optional request bodies do not require flattened body fields', () => {
+    const commands = Openapi.generateCommands(
+      {
+        openapi: '3.0.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/users': {
+            post: {
+              operationId: 'createUser',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { name: { type: 'string' } },
+                      required: ['name'],
+                    },
+                  },
+                },
+              },
+              responses: { 200: { description: 'OK' } },
+            },
+          },
+        },
+      },
+      app.fetch,
+    )
+
+    expect(commands.get('createUser')!.options!.parse({})).toEqual({})
+  })
 })
 
 describe('cli integration', () => {

--- a/src/Openapi.ts
+++ b/src/Openapi.ts
@@ -22,12 +22,15 @@ export type OpenAPISpec = {
 }
 
 /** Command map generated from an OpenAPI spec mounted at `name`. */
-export type CommandMap<name extends string, spec extends OpenAPISpec> =
-  spec extends { paths: infer paths }
-    ? EntriesToMap<{
+export type CommandMap<name extends string, spec extends OpenAPISpec> = spec extends {
+  paths: infer paths
+}
+  ? EntriesToMap<
+      {
         [path in keyof paths & string]: OperationEntries<name, path, paths[path]>
-      }[keyof paths & string]>
-    : {}
+      }[keyof paths & string]
+    >
+  : {}
 
 /** Options for generating an OpenAPI document from an incur CLI. */
 export type GenerateOptions = {
@@ -91,44 +94,45 @@ type RequestBody = {
   required?: boolean | undefined
 }
 
-type HttpOperationMethod =
-  | 'delete'
-  | 'get'
-  | 'head'
-  | 'options'
-  | 'patch'
-  | 'post'
-  | 'put'
-  | 'trace'
+const openApiMethodNames = [
+  'delete',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+  'query',
+  'trace',
+] as const
 
-type OperationEntries<
-  name extends string,
-  path extends string,
-  methods,
-> = methods extends Record<string, unknown>
-  ? {
-      [method in keyof methods & HttpOperationMethod]: methods[method] extends Record<
-        string,
-        unknown
-      >
-        ? {
-            name: `${name} ${OperationName<method, path, methods[method]>}`
-            entry: {
-              args: ParametersToObject<
-                PathItemParameters<methods> | OperationParameters<methods[method]>,
-                'path'
-              >
-              options: ParametersToObject<
-                PathItemParameters<methods> | OperationParameters<methods[method]>,
-                'query'
-              > &
-                RequestBodyToObject<OperationRequestBody<methods[method]>>
-              output: OperationOutput<methods[method]>
+type HttpOperationMethod = (typeof openApiMethodNames)[number]
+
+type OperationEntries<name extends string, path extends string, methods> =
+  methods extends Record<string, unknown>
+    ? {
+        [method in keyof methods & HttpOperationMethod]: methods[method] extends Record<
+          string,
+          unknown
+        >
+          ? {
+              name: `${name} ${OperationName<method, path, methods[method]>}`
+              entry: {
+                args: ParametersToObject<
+                  PathItemParameters<methods> | OperationParameters<methods[method]>,
+                  'path'
+                >
+                options: ParametersToObject<
+                  PathItemParameters<methods> | OperationParameters<methods[method]>,
+                  'query'
+                > &
+                  RequestBodyToObject<OperationRequestBody<methods[method]>>
+                output: OperationOutput<methods[method]>
+              }
             }
-          }
-        : never
-    }[keyof methods & HttpOperationMethod]
-  : never
+          : never
+      }[keyof methods & HttpOperationMethod]
+    : never
 
 type EntriesToMap<entries> = UnionToIntersection<
   entries extends { entry: unknown; name: string }
@@ -204,26 +208,30 @@ type RequestBodyToObject<body> = [body] extends [
     content: { 'application/json': { schema: infer schema } }
   },
 ]
-  ? SchemaObjectToType<schema>
+  ? body extends { required: true }
+    ? SchemaObjectToType<schema>
+    : OptionalSchemaObjectToType<schema>
   : {}
 
 type OperationOutput<operation> = operation extends { responses: infer responses }
   ? ResponseOutput<responses>
   : unknown
 
-type ResponseOutput<responses> = ResponseContent<PickSuccessResponse<responses>> extends infer schema
-  ? [schema] extends [never]
-    ? unknown
-    : JsonSchemaToType<schema>
-  : unknown
+type ResponseOutput<responses> =
+  ResponseContent<PickSuccessResponse<responses>> extends infer schema
+    ? [schema] extends [never]
+      ? unknown
+      : JsonSchemaToType<schema>
+    : unknown
 
-type PickSuccessResponse<responses> = responses extends Record<PropertyKey, unknown>
-  ? '200' extends keyof responses
-    ? responses['200']
-    : 200 extends keyof responses
-      ? responses[200]
-      : SuccessResponse<responses>
-  : never
+type PickSuccessResponse<responses> =
+  responses extends Record<PropertyKey, unknown>
+    ? '200' extends keyof responses
+      ? responses['200']
+      : 200 extends keyof responses
+        ? responses[200]
+        : SuccessResponse<responses>
+    : never
 
 type SuccessResponse<responses> = {
   [status in keyof responses]: `${status & (number | string)}` extends `2${string}`
@@ -255,10 +263,16 @@ type RequiredSchemaProps<properties extends Record<string, unknown>, required ex
 }
 
 type OptionalSchemaProps<properties extends Record<string, unknown>, required extends string> = {
-  [key in keyof properties & string as key extends required ? never : key]?: JsonSchemaToType<
-    properties[key]
-  > | undefined
+  [key in keyof properties & string as key extends required ? never : key]?:
+    | JsonSchemaToType<properties[key]>
+    | undefined
 }
+
+type OptionalSchemaObjectToType<schema> = schema extends {
+  properties: infer properties extends Record<string, unknown>
+}
+  ? { [key in keyof properties & string]?: JsonSchemaToType<properties[key]> | undefined }
+  : {}
 
 type JsonSchemaToType<schema> = schema extends { const: infer value }
   ? value
@@ -290,16 +304,7 @@ type JsonSchemaTypeToType<type, schema> = type extends 'string'
             ? SchemaObjectToType<schema>
             : unknown
 
-const openApiMethods = new Set([
-  'delete',
-  'get',
-  'head',
-  'options',
-  'patch',
-  'post',
-  'put',
-  'trace',
-])
+const openApiMethods = new Set<string>(openApiMethodNames)
 
 /** A fetch handler. */
 type FetchHandler = (req: Request) => Response | Promise<Response>
@@ -516,7 +521,9 @@ export function generateCommands(
 
       const bodySchema = op.requestBody?.content?.['application/json']?.schema
       const bodyProps = (bodySchema?.properties ?? {}) as Record<string, Record<string, unknown>>
-      const bodyRequired = new Set((bodySchema?.required as string[]) ?? [])
+      const bodyRequired = new Set(
+        op.requestBody?.required ? ((bodySchema?.required as string[]) ?? []) : [],
+      )
       const outputSchema = successResponseSchema(op.responses)
 
       // Build args Zod schema from path params
@@ -571,9 +578,9 @@ export function generateCommands(
 function successResponseSchema(responses: Record<string, unknown> | undefined) {
   if (!responses) return undefined
   const entries = Object.entries(responses)
-  const match = entries.find(([status]) => status === '200') ?? entries.find(([status]) =>
-    status.startsWith('2'),
-  )
+  const match =
+    entries.find(([status]) => status === '200') ??
+    entries.find(([status]) => status.startsWith('2'))
   const response = match?.[1] as
     | { content?: Record<string, { schema?: Record<string, unknown> | undefined }> | undefined }
     | undefined
@@ -596,7 +603,8 @@ function createHandler(config: {
     let urlPath = (config.basePath ?? '') + config.path
     for (const p of config.pathParams) {
       const value = args[p.name]
-      if (value !== undefined) urlPath = urlPath.replace(`{${p.name}}`, String(value))
+      if (value !== undefined)
+        urlPath = urlPath.replace(`{${p.name}}`, encodeURIComponent(String(value)))
     }
 
     // Build query string from query params
@@ -660,14 +668,14 @@ function coerceIfNeeded(schema: z.ZodType): z.ZodType {
       return isOptional ? z.coerce.number().optional() : z.coerce.number()
     // Direct boolean
     if (inner instanceof z.ZodBoolean)
-      return isOptional ? z.coerce.boolean().optional() : z.coerce.boolean()
+      return isOptional ? booleanParam(inner).optional() : booleanParam(inner)
     // Union containing number or boolean (e.g. type: ["number", "null"] from OpenAPI 3.1)
     if (inner instanceof z.ZodUnion) {
       const options = (inner as any)._zod?.def?.options as z.ZodType[] | undefined
       if (options?.some((o: z.ZodType) => o instanceof z.ZodNumber))
         return isOptional ? z.coerce.number().optional() : z.coerce.number()
       if (options?.some((o: z.ZodType) => o instanceof z.ZodBoolean))
-        return isOptional ? z.coerce.boolean().optional() : z.coerce.boolean()
+        return isOptional ? booleanParam(inner).optional() : booleanParam(inner)
     }
     // No coercion needed
     return undefined
@@ -676,4 +684,13 @@ function coerceIfNeeded(schema: z.ZodType): z.ZodType {
   if (!coerced) return schema
   const desc = (schema as any).description ?? (inner as any).description
   return desc ? coerced.describe(desc) : coerced
+}
+
+function booleanParam(schema: z.ZodType) {
+  return z.preprocess((value) => {
+    if (typeof value !== 'string') return value
+    if (value === 'true') return true
+    if (value === 'false') return false
+    return value
+  }, schema)
 }

--- a/src/Openapi.ts
+++ b/src/Openapi.ts
@@ -12,7 +12,22 @@ import { dereference } from './internal/dereference.js'
 import * as Schema from './Schema.js'
 
 /** A minimal OpenAPI 3.x spec shape. Accepts both hand-written specs and generated ones (e.g. from `@hono/zod-openapi`). */
-export type OpenAPISpec = { paths?: {} | undefined }
+export type OpenAPISpec = {
+  /** OpenAPI document metadata. */
+  info?: unknown
+  /** OpenAPI version string. */
+  openapi?: string | undefined
+  /** OpenAPI path table keyed by URL path. */
+  paths?: Record<string, Record<string, unknown>> | undefined
+}
+
+/** Command map generated from an OpenAPI spec mounted at `name`. */
+export type CommandMap<name extends string, spec extends OpenAPISpec> =
+  spec extends { paths: infer paths }
+    ? EntriesToMap<{
+        [path in keyof paths & string]: OperationEntries<name, path, paths[path]>
+      }[keyof paths & string]>
+    : {}
 
 /** Options for generating an OpenAPI document from an incur CLI. */
 export type GenerateOptions = {
@@ -76,6 +91,216 @@ type RequestBody = {
   required?: boolean | undefined
 }
 
+type HttpOperationMethod =
+  | 'delete'
+  | 'get'
+  | 'head'
+  | 'options'
+  | 'patch'
+  | 'post'
+  | 'put'
+  | 'trace'
+
+type OperationEntries<
+  name extends string,
+  path extends string,
+  methods,
+> = methods extends Record<string, unknown>
+  ? {
+      [method in keyof methods & HttpOperationMethod]: methods[method] extends Record<
+        string,
+        unknown
+      >
+        ? {
+            name: `${name} ${OperationName<method, path, methods[method]>}`
+            entry: {
+              args: ParametersToObject<
+                PathItemParameters<methods> | OperationParameters<methods[method]>,
+                'path'
+              >
+              options: ParametersToObject<
+                PathItemParameters<methods> | OperationParameters<methods[method]>,
+                'query'
+              > &
+                RequestBodyToObject<OperationRequestBody<methods[method]>>
+              output: OperationOutput<methods[method]>
+            }
+          }
+        : never
+    }[keyof methods & HttpOperationMethod]
+  : never
+
+type EntriesToMap<entries> = UnionToIntersection<
+  entries extends { entry: unknown; name: string }
+    ? { [key in entries['name']]: entries['entry'] }
+    : unknown
+>
+
+type UnionToIntersection<value> = (value extends unknown ? (arg: value) => void : never) extends (
+  arg: infer result,
+) => void
+  ? result
+  : never
+
+type OperationName<method extends string, path extends string, operation> = operation extends {
+  operationId: infer id extends string
+}
+  ? id
+  : `${method}_${ReplacePathChars<path>}`
+
+type ReplacePathChars<value extends string> = value extends `${infer head}/${infer tail}`
+  ? `${head}_${ReplacePathChars<tail>}`
+  : value extends `${infer head}{${infer tail}`
+    ? `${head}_${ReplacePathChars<tail>}`
+    : value extends `${infer head}}${infer tail}`
+      ? `${head}_${ReplacePathChars<tail>}`
+      : value
+
+type OperationParameters<operation> = operation extends {
+  parameters: infer parameters extends readonly unknown[]
+}
+  ? parameters[number]
+  : never
+
+type PathItemParameters<pathItem> = pathItem extends {
+  parameters: infer parameters extends readonly unknown[]
+}
+  ? parameters[number]
+  : never
+
+type OperationRequestBody<operation> = operation extends { requestBody: infer body } ? body : never
+
+type ParametersToObject<parameter, location extends string> = RequiredParameterProps<
+  parameter,
+  location
+> &
+  OptionalParameterProps<parameter, location>
+
+type RequiredParameterProps<parameter, location extends string> = {
+  [item in parameter as item extends {
+    in: location
+    name: infer name extends string
+    required: true
+  }
+    ? name
+    : never]: item extends { schema: infer schema } ? JsonSchemaToType<schema> : string
+}
+
+type OptionalParameterProps<parameter, location extends string> = {
+  [item in parameter as item extends {
+    in: location
+    name: infer name extends string
+  }
+    ? item extends { required: true }
+      ? never
+      : name
+    : never]?: item extends { schema: infer schema }
+    ? JsonSchemaToType<schema> | undefined
+    : string | undefined
+}
+
+type RequestBodyToObject<body> = [body] extends [
+  {
+    content: { 'application/json': { schema: infer schema } }
+  },
+]
+  ? SchemaObjectToType<schema>
+  : {}
+
+type OperationOutput<operation> = operation extends { responses: infer responses }
+  ? ResponseOutput<responses>
+  : unknown
+
+type ResponseOutput<responses> = ResponseContent<PickSuccessResponse<responses>> extends infer schema
+  ? [schema] extends [never]
+    ? unknown
+    : JsonSchemaToType<schema>
+  : unknown
+
+type PickSuccessResponse<responses> = responses extends Record<PropertyKey, unknown>
+  ? '200' extends keyof responses
+    ? responses['200']
+    : 200 extends keyof responses
+      ? responses[200]
+      : SuccessResponse<responses>
+  : never
+
+type SuccessResponse<responses> = {
+  [status in keyof responses]: `${status & (number | string)}` extends `2${string}`
+    ? responses[status]
+    : never
+}[keyof responses]
+
+type ResponseContent<response> = response extends {
+  content: { 'application/json': { schema: infer schema } }
+}
+  ? schema
+  : never
+
+type SchemaObjectToType<schema> = schema extends {
+  properties: infer properties extends Record<string, unknown>
+}
+  ? RequiredSchemaProps<properties, RequiredKeys<schema>> &
+      OptionalSchemaProps<properties, RequiredKeys<schema>>
+  : {}
+
+type RequiredKeys<schema> = schema extends { required: infer required extends readonly string[] }
+  ? required[number]
+  : never
+
+type RequiredSchemaProps<properties extends Record<string, unknown>, required extends string> = {
+  [key in keyof properties & string as key extends required ? key : never]: JsonSchemaToType<
+    properties[key]
+  >
+}
+
+type OptionalSchemaProps<properties extends Record<string, unknown>, required extends string> = {
+  [key in keyof properties & string as key extends required ? never : key]?: JsonSchemaToType<
+    properties[key]
+  > | undefined
+}
+
+type JsonSchemaToType<schema> = schema extends { const: infer value }
+  ? value
+  : schema extends { enum: infer values extends readonly unknown[] }
+    ? values[number]
+    : schema extends { anyOf: infer values extends readonly unknown[] }
+      ? JsonSchemaToType<values[number]>
+      : schema extends { oneOf: infer values extends readonly unknown[] }
+        ? JsonSchemaToType<values[number]>
+        : schema extends { type: infer type extends readonly unknown[] }
+          ? JsonSchemaTypeToType<type[number], schema>
+          : schema extends { type: infer type }
+            ? JsonSchemaTypeToType<type, schema>
+            : unknown
+
+type JsonSchemaTypeToType<type, schema> = type extends 'string'
+  ? string
+  : type extends 'number' | 'integer'
+    ? number
+    : type extends 'boolean'
+      ? boolean
+      : type extends 'null'
+        ? null
+        : type extends 'array'
+          ? schema extends { items: infer item }
+            ? JsonSchemaToType<item>[]
+            : unknown[]
+          : type extends 'object'
+            ? SchemaObjectToType<schema>
+            : unknown
+
+const openApiMethods = new Set([
+  'delete',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+  'trace',
+])
+
 /** A fetch handler. */
 type FetchHandler = (req: Request) => Response | Promise<Response>
 
@@ -84,6 +309,7 @@ type GeneratedCommand = {
   args?: z.ZodObject<any> | undefined
   description?: string | undefined
   options?: z.ZodObject<any> | undefined
+  output?: z.ZodType | undefined
   run: (context: any) => any
 }
 
@@ -266,28 +492,32 @@ function encodePathSegment(segment: string) {
 }
 
 /** Generates incur command entries from an OpenAPI spec. Resolves all `$ref` pointers. */
-export async function generateCommands(
+export function generateCommands(
   spec: OpenAPISpec,
   fetch: FetchHandler,
   options: { basePath?: string | undefined } = {},
-): Promise<Map<string, GeneratedCommand>> {
+): Map<string, GeneratedCommand> {
   const resolved = dereference(structuredClone(spec)) as OpenAPISpec
   const commands = new Map<string, GeneratedCommand>()
   const paths = (resolved.paths ?? {}) as Record<string, Record<string, unknown>>
 
   for (const [path, methods] of Object.entries(paths)) {
+    const pathItem = methods as { parameters?: readonly Parameter[] | undefined }
+    const pathParameters = pathItem.parameters ?? []
     for (const [method, operation] of Object.entries(methods)) {
-      if (method.startsWith('x-')) continue
+      if (!openApiMethods.has(method)) continue
       const op = operation as Operation
       const name = op.operationId ?? `${method}_${path.replace(/[/{}]/g, '_')}`
       const httpMethod = method.toUpperCase()
 
-      const pathParams = (op.parameters ?? []).filter((p) => p.in === 'path')
-      const queryParams = (op.parameters ?? []).filter((p) => p.in === 'query')
+      const parameters = [...pathParameters, ...(op.parameters ?? [])]
+      const pathParams = parameters.filter((p) => p.in === 'path')
+      const queryParams = parameters.filter((p) => p.in === 'query')
 
       const bodySchema = op.requestBody?.content?.['application/json']?.schema
       const bodyProps = (bodySchema?.properties ?? {}) as Record<string, Record<string, unknown>>
       const bodyRequired = new Set((bodySchema?.required as string[]) ?? [])
+      const outputSchema = successResponseSchema(op.responses)
 
       // Build args Zod schema from path params
       let argsSchema: z.ZodObject<any> | undefined
@@ -321,6 +551,7 @@ export async function generateCommands(
         description: op.summary ?? op.description,
         args: argsSchema,
         options: optionsSchema,
+        ...(outputSchema ? { output: toZod(outputSchema) } : undefined),
         run: createHandler({
           basePath: options.basePath,
           fetch,
@@ -335,6 +566,18 @@ export async function generateCommands(
   }
 
   return commands
+}
+
+function successResponseSchema(responses: Record<string, unknown> | undefined) {
+  if (!responses) return undefined
+  const entries = Object.entries(responses)
+  const match = entries.find(([status]) => status === '200') ?? entries.find(([status]) =>
+    status.startsWith('2'),
+  )
+  const response = match?.[1] as
+    | { content?: Record<string, { schema?: Record<string, unknown> | undefined }> | undefined }
+    | undefined
+  return response?.content?.['application/json']?.schema
 }
 
 function createHandler(config: {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -257,7 +257,7 @@ function setOption(
 }
 
 /** Wraps zod schema.parse(), converting ZodError to ValidationError. */
-function zodParse(schema: z.ZodObject<any>, data: Record<string, unknown>) {
+export function zodParse(schema: z.ZodObject<any>, data: Record<string, unknown>) {
   try {
     return schema.parse(data)
   } catch (err: any) {

--- a/src/Register.ts
+++ b/src/Register.ts
@@ -7,7 +7,7 @@
  * declare module 'incur' {
  *   interface Register {
  *     commands: {
- *       get: { args: { id: number }; options: {} }
+ *       get: { args: { id: number }; options: {}; output: { name: string } }
  *       list: { args: {}; options: { limit: number } }
  *     }
  *   }

--- a/src/Typegen.test.ts
+++ b/src/Typegen.test.ts
@@ -1,4 +1,5 @@
 import { Cli, Typegen, z } from 'incur'
+
 import { app, spec } from '../test/fixtures/hono-openapi-app.js'
 
 describe('fromCli', () => {
@@ -17,9 +18,9 @@ describe('fromCli', () => {
       "/** Command map generated from your incur CLI. */
       export type Commands = {
         /** Generated command "get". */
-        'get': { args: { id: number }; options: {} }
+        "get": { args: { id: number }; options: {} }
         /** Generated command "list". */
-        'list': { args: {}; options: { limit: number } }
+        "list": { args: {}; options: { limit: number } }
       }
 
       declare module 'incur' {
@@ -38,7 +39,7 @@ describe('fromCli', () => {
       "/** Command map generated from your incur CLI. */
       export type Commands = {
         /** Generated command "ping". */
-        'ping': { args: {}; options: {} }
+        "ping": { args: {}; options: {} }
       }
 
       declare module 'incur' {
@@ -67,9 +68,9 @@ describe('fromCli', () => {
       "/** Command map generated from your incur CLI. */
       export type Commands = {
         /** Generated command "pr create". */
-        'pr create': { args: { title: string }; options: {} }
+        "pr create": { args: { title: string }; options: {} }
         /** Generated command "pr list". */
-        'pr list': { args: {}; options: { state: string } }
+        "pr list": { args: {}; options: { state: string } }
       }
 
       declare module 'incur' {
@@ -95,7 +96,7 @@ describe('fromCli', () => {
       "/** Command map generated from your incur CLI. */
       export type Commands = {
         /** Generated command "pr review approve". */
-        'pr review approve': { args: { id: number }; options: {} }
+        "pr review approve": { args: { id: number }; options: {} }
       }
 
       declare module 'incur' {
@@ -144,7 +145,7 @@ describe('fromCli', () => {
       .command('middle', { run: () => ({}) })
 
     const output = Typegen.fromCli(cli)
-    const commandOrder = [...output.matchAll(/^  '(\w+)':/gm)].map((m) => m[1])
+    const commandOrder = [...output.matchAll(/^  "(\w+)":/gm)].map((m) => m[1])
     expect(commandOrder).toEqual(['alpha', 'middle', 'zebra'])
   })
 
@@ -227,7 +228,7 @@ describe('fromCli', () => {
       "/** Command map generated from your incur CLI. */
       export type Commands = {
         /** Generated command "build". */
-        'build': { args: {}; options: { name: string; count: number; active: boolean; mode: "strict"; state: "open" | "closed"; target: string | number; values: ("a" | 1 | boolean)[]; nested: { label?: string | undefined; flags: ("on" | "off")[] } } }
+        "build": { args: {}; options: { name: string; count: number; active: boolean; mode: "strict"; state: "open" | "closed"; target: string | number; values: ("a" | 1 | boolean)[]; nested: { label?: string | undefined; flags: ("on" | "off")[] } } }
       }
 
       declare module 'incur' {
@@ -246,7 +247,7 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain("'cmd': { args: {}; options: {}; output: { ok: boolean } }")
+    expect(output).toContain('"cmd": { args: {}; options: {}; output: { ok: boolean } }')
   })
 
   test('output schemas for non-object top-level types', () => {
@@ -261,8 +262,8 @@ describe('fromCli', () => {
       })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain("'text': { args: {}; options: {}; output: string }")
-    expect(output).toContain("'values': { args: {}; options: {}; output: (string | number)[] }")
+    expect(output).toContain('"text": { args: {}; options: {}; output: string }')
+    expect(output).toContain('"values": { args: {}; options: {}; output: (string | number)[] }')
   })
 
   test('output schemas for records and tuples', () => {
@@ -285,15 +286,15 @@ describe('fromCli', () => {
       })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain("'record': { args: {}; options: {}; output: Record<string, number> }")
+    expect(output).toContain('"record": { args: {}; options: {}; output: Record<string, number> }')
     expect(output).toContain(
-      '\'enum-record\': { args: {}; options: {}; output: Record<"left" | "right", number> }',
+      '"enum-record": { args: {}; options: {}; output: Record<"left" | "right", number> }',
     )
     expect(output).toContain(
-      "'rest-tuple': { args: {}; options: {}; output: [string, ...number[]] }",
+      '"rest-tuple": { args: {}; options: {}; output: [string, ...number[]] }',
     )
     expect(output).toContain(
-      "'tuple': { args: {}; options: {}; output: [string, number, boolean] }",
+      '"tuple": { args: {}; options: {}; output: [string, number, boolean] }',
     )
   })
 
@@ -304,7 +305,7 @@ describe('fromCli', () => {
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain("'cmd': { args: {}; options: {}; output: unknown }")
+    expect(output).toContain('"cmd": { args: {}; options: {}; output: unknown }')
   })
 
   test('object keys that are not identifiers are quoted', () => {
@@ -319,6 +320,27 @@ describe('fromCli', () => {
     const output = Typegen.fromCli(cli)
     expect(output).toContain('"1x": number')
     expect(output).toContain('"foo-bar": string')
+  })
+
+  test('command keys are escaped', () => {
+    const cli = Cli.create('test').command('quote\'s "cmd" \\ slash */ end', {
+      run: () => ({}),
+    })
+
+    const output = Typegen.fromCli(cli)
+    expect(output).toContain('Generated command "quote\'s \\"cmd\\" \\\\ slash *\\/ end"')
+    expect(output).toContain('"quote\'s \\"cmd\\" \\\\ slash */ end": { args: {}; options: {} }')
+  })
+
+  test('catchall output widens the index signature for known properties', () => {
+    const cli = Cli.create('test').command('cmd', {
+      output: z.object({ name: z.string() }).catchall(z.number()),
+      run: () => ({ name: 'test' }) as never,
+    })
+
+    expect(Typegen.fromCli(cli)).toContain(
+      '"cmd": { args: {}; options: {}; output: { name: string; [key: string]: number | string } }',
+    )
   })
 
   test('unsupported schemas throw a clear typegen error', () => {
@@ -344,7 +366,7 @@ describe('fromCli', () => {
       "/** Command map generated from your incur CLI. */
       export type Commands = {
         /** Generated command "deploy". */
-        'deploy': { args: {}; options: {} }
+        "deploy": { args: {}; options: {} }
       }
 
       declare module 'incur' {
@@ -364,12 +386,12 @@ describe('fromCli', () => {
 
     const output = Typegen.fromCli(cli)
     expect(output).toContain(
-      "'api getUser': { args: { id: number }; options: {}; output: { id: number; name: string; [key: string]: unknown } }",
+      '"api getUser": { args: { id: number }; options: {}; output: { id: number; name: string; [key: string]: unknown } }',
     )
     expect(output).toContain(
-      "'api createUser': { args: {}; options: { name: string }; output: { created: boolean; name: string; [key: string]: unknown } }",
+      '"api createUser": { args: {}; options: { name: string }; output: { created: boolean; name: string; [key: string]: unknown } }',
     )
-    expect(output).not.toContain("'api': { args")
+    expect(output).not.toContain('"api": { args')
   })
 
   test('mixed top-level and grouped commands', () => {
@@ -382,9 +404,9 @@ describe('fromCli', () => {
       "/** Command map generated from your incur CLI. */
       export type Commands = {
         /** Generated command "ping". */
-        'ping': { args: {}; options: {} }
+        "ping": { args: {}; options: {} }
         /** Generated command "pr list". */
-        'pr list': { args: {}; options: {} }
+        "pr list": { args: {}; options: {} }
       }
 
       declare module 'incur' {

--- a/src/Typegen.test.ts
+++ b/src/Typegen.test.ts
@@ -1,4 +1,5 @@
 import { Cli, Typegen, z } from 'incur'
+import fs from 'node:fs/promises'
 
 import { app, spec } from '../test/fixtures/hono-openapi-app.js'
 
@@ -417,4 +418,149 @@ describe('fromCli', () => {
       "
     `)
   })
+
+  test('generated client type fixture matches fromCli output', async () => {
+    const output = await fs.readFile(new URL('./Client.test-d.ts', import.meta.url), 'utf8')
+    const fixture = extractGeneratedClientFixture(output)
+    expect(normalizeDeclaration(Typegen.fromCli(createClientRoundTripCli()))).toBe(
+      normalizeDeclaration(fixture),
+    )
+  })
 })
+
+function extractGeneratedClientFixture(value: string): string {
+  const start = '// BEGIN generated client round-trip fixture'
+  const end = '// END generated client round-trip fixture'
+  return value.slice(value.indexOf(start) + start.length, value.indexOf(end)).trimStart()
+}
+
+function normalizeDeclaration(value: string): string {
+  let output = ''
+  let quote = ''
+  let escaping = false
+
+  for (const char of value) {
+    if (quote) {
+      if (escaping) {
+        output += char
+        escaping = false
+        continue
+      }
+      if (char === '\\') {
+        output += char
+        escaping = true
+        continue
+      }
+      if (char === quote) {
+        output += '"'
+        quote = ''
+        continue
+      }
+      output += char
+      continue
+    }
+
+    if (char === "'" || char === '"') {
+      output += '"'
+      quote = char
+      continue
+    }
+    if (char === ';' || /\s/.test(char)) continue
+    output += char
+  }
+
+  return output.replace(/"([A-Za-z_$][\w$]*)":/g, '$1:')
+}
+
+function createClientRoundTripCli() {
+  const spec = {
+    openapi: '3.0.0',
+    info: { title: 'Test', version: '1.0.0' },
+    paths: {
+      '/users/{id}': {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'number' },
+          },
+        ],
+        get: {
+          operationId: 'getUser',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { id: { type: 'number' }, name: { type: 'string' } },
+                    required: ['id', 'name'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  } as const
+  const status = Cli.create('status', {
+    output: z.object({ ok: z.boolean() }),
+    run: () => ({ ok: true }),
+  })
+  const project = Cli.create('project')
+    .command('deploy', {
+      aliases: ['ship'],
+      args: z.object({ id: z.string() }),
+      options: z.object({ dryRun: z.boolean() }),
+      output: z.object({
+        deployId: z.string(),
+        status: z.enum(['queued', 'done']),
+      }),
+      run: () => ({ deployId: 'dep_123', status: 'queued' as const }),
+    })
+    .command('inspect', {
+      args: z.object({
+        id: z.string(),
+        includeLogs: z.boolean().optional(),
+      }),
+      output: z.object({
+        id: z.string(),
+        logs: z.array(z.string()).optional(),
+      }),
+      run: (c) => ({ id: c.args.id }),
+    })
+    .command('list', {
+      options: z.object({
+        cursor: z.string().optional(),
+        limit: z.number().optional(),
+      }),
+      output: z.object({
+        items: z.array(z.string()),
+        nextCursor: z.string().optional(),
+      }),
+      run: () => ({ items: [] }),
+    })
+  const users = Cli.create('users').command('get', {
+    args: z.object({ id: z.number() }),
+    options: z.object({ verbose: z.boolean().optional() }),
+    output: z.object({ id: z.number() }),
+    run: (c) => ({ id: c.args.id }),
+  })
+
+  return Cli.create('test')
+    .command(status)
+    .command(project)
+    .command(Cli.create('admin').command(users))
+    .command('auth', {
+      options: z.object({ token: z.string() }),
+      output: z.void(),
+      run: () => undefined,
+    })
+    .command('api', {
+      fetch: () => new Response(),
+      openapi: spec,
+    })
+}

--- a/src/Typegen.test.ts
+++ b/src/Typegen.test.ts
@@ -1,4 +1,5 @@
 import { Cli, Typegen, z } from 'incur'
+import { app, spec } from '../test/fixtures/hono-openapi-app.js'
 
 describe('fromCli', () => {
   test('simple commands with args and options', () => {
@@ -13,12 +14,17 @@ describe('fromCli', () => {
       })
 
     expect(Typegen.fromCli(cli)).toMatchInlineSnapshot(`
-      "declare module 'incur' {
+      "/** Command map generated from your incur CLI. */
+      export type Commands = {
+        /** Generated command "get". */
+        'get': { args: { id: number }; options: {} }
+        /** Generated command "list". */
+        'list': { args: {}; options: { limit: number } }
+      }
+
+      declare module 'incur' {
         interface Register {
-          commands: {
-            'get': { args: { id: number }; options: {} }
-            'list': { args: {}; options: { limit: number } }
-          }
+          commands: Commands
         }
       }
       "
@@ -29,11 +35,15 @@ describe('fromCli', () => {
     const cli = Cli.create('test').command('ping', { run: () => ({}) })
 
     expect(Typegen.fromCli(cli)).toMatchInlineSnapshot(`
-      "declare module 'incur' {
+      "/** Command map generated from your incur CLI. */
+      export type Commands = {
+        /** Generated command "ping". */
+        'ping': { args: {}; options: {} }
+      }
+
+      declare module 'incur' {
         interface Register {
-          commands: {
-            'ping': { args: {}; options: {} }
-          }
+          commands: Commands
         }
       }
       "
@@ -54,12 +64,17 @@ describe('fromCli', () => {
     cli.command(pr)
 
     expect(Typegen.fromCli(cli)).toMatchInlineSnapshot(`
-      "declare module 'incur' {
+      "/** Command map generated from your incur CLI. */
+      export type Commands = {
+        /** Generated command "pr create". */
+        'pr create': { args: { title: string }; options: {} }
+        /** Generated command "pr list". */
+        'pr list': { args: {}; options: { state: string } }
+      }
+
+      declare module 'incur' {
         interface Register {
-          commands: {
-            'pr create': { args: { title: string }; options: {} }
-            'pr list': { args: {}; options: { state: string } }
-          }
+          commands: Commands
         }
       }
       "
@@ -77,11 +92,15 @@ describe('fromCli', () => {
     cli.command(pr)
 
     expect(Typegen.fromCli(cli)).toMatchInlineSnapshot(`
-      "declare module 'incur' {
+      "/** Command map generated from your incur CLI. */
+      export type Commands = {
+        /** Generated command "pr review approve". */
+        'pr review approve': { args: { id: number }; options: {} }
+      }
+
+      declare module 'incur' {
         interface Register {
-          commands: {
-            'pr review approve': { args: { id: number }; options: {} }
-          }
+          commands: Commands
         }
       }
       "
@@ -125,7 +144,7 @@ describe('fromCli', () => {
       .command('middle', { run: () => ({}) })
 
     const output = Typegen.fromCli(cli)
-    const commandOrder = [...output.matchAll(/^ {6}'(\w+)':/gm)].map((m) => m[1])
+    const commandOrder = [...output.matchAll(/^  '(\w+)':/gm)].map((m) => m[1])
     expect(commandOrder).toEqual(['alpha', 'middle', 'zebra'])
   })
 
@@ -169,19 +188,188 @@ describe('fromCli', () => {
     expect(output).toContain('config: { host: string; port: number }')
   })
 
-  test('optional properties use optional modifier', () => {
+  test('optional properties include undefined for exactOptionalPropertyTypes', () => {
     const cli = Cli.create('test').command('create', {
       args: z.object({ name: z.string() }),
       options: z.object({
         verbose: z.boolean().optional(),
+        nullable: z.string().nullable().optional(),
         output: z.string(),
       }),
       run: () => ({}),
     })
 
     const output = Typegen.fromCli(cli)
-    expect(output).toContain('verbose?: boolean')
+    expect(output).toContain('verbose?: boolean | undefined')
+    expect(output).toContain('nullable?: string | null | undefined')
     expect(output).toContain('output: string')
+  })
+
+  test('dense object schema', () => {
+    const cli = Cli.create('test').command('build', {
+      options: z.object({
+        name: z.string(),
+        count: z.number(),
+        active: z.boolean(),
+        mode: z.literal('strict'),
+        state: z.enum(['open', 'closed']),
+        target: z.union([z.string(), z.number()]),
+        values: z.array(z.union([z.literal('a'), z.literal(1), z.boolean()])),
+        nested: z.object({
+          label: z.string().optional(),
+          flags: z.array(z.enum(['on', 'off'])),
+        }),
+      }),
+      run: () => ({}),
+    })
+
+    expect(Typegen.fromCli(cli)).toMatchInlineSnapshot(`
+      "/** Command map generated from your incur CLI. */
+      export type Commands = {
+        /** Generated command "build". */
+        'build': { args: {}; options: { name: string; count: number; active: boolean; mode: "strict"; state: "open" | "closed"; target: string | number; values: ("a" | 1 | boolean)[]; nested: { label?: string | undefined; flags: ("on" | "off")[] } } }
+      }
+
+      declare module 'incur' {
+        interface Register {
+          commands: Commands
+        }
+      }
+      "
+    `)
+  })
+
+  test('command output schema', () => {
+    const cli = Cli.create('test').command('cmd', {
+      output: z.object({ ok: z.boolean() }),
+      run: () => ({ ok: true }),
+    })
+
+    const output = Typegen.fromCli(cli)
+    expect(output).toContain("'cmd': { args: {}; options: {}; output: { ok: boolean } }")
+  })
+
+  test('output schemas for non-object top-level types', () => {
+    const cli = Cli.create('test')
+      .command('text', {
+        output: z.string(),
+        run: () => 'ok',
+      })
+      .command('values', {
+        output: z.array(z.union([z.string(), z.number()])),
+        run: () => ['ok', 1],
+      })
+
+    const output = Typegen.fromCli(cli)
+    expect(output).toContain("'text': { args: {}; options: {}; output: string }")
+    expect(output).toContain("'values': { args: {}; options: {}; output: (string | number)[] }")
+  })
+
+  test('output schemas for records and tuples', () => {
+    const cli = Cli.create('test')
+      .command('record', {
+        output: z.record(z.string(), z.number()),
+        run: () => ({ count: 1 }),
+      })
+      .command('enum-record', {
+        output: z.record(z.enum(['left', 'right']), z.number()),
+        run: () => ({ left: 1, right: 2 }),
+      })
+      .command('tuple', {
+        output: z.tuple([z.string(), z.number(), z.boolean()]),
+        run: () => ['ok', 1, true] as [string, number, boolean],
+      })
+      .command('rest-tuple', {
+        output: z.tuple([z.string()]).rest(z.number()),
+        run: () => ['ok', 1, 2] as [string, ...number[]],
+      })
+
+    const output = Typegen.fromCli(cli)
+    expect(output).toContain("'record': { args: {}; options: {}; output: Record<string, number> }")
+    expect(output).toContain(
+      '\'enum-record\': { args: {}; options: {}; output: Record<"left" | "right", number> }',
+    )
+    expect(output).toContain(
+      "'rest-tuple': { args: {}; options: {}; output: [string, ...number[]] }",
+    )
+    expect(output).toContain(
+      "'tuple': { args: {}; options: {}; output: [string, number, boolean] }",
+    )
+  })
+
+  test('unknown output schemas fall back to unknown', () => {
+    const cli = Cli.create('test').command('cmd', {
+      output: z.any(),
+      run: () => ({}),
+    })
+
+    const output = Typegen.fromCli(cli)
+    expect(output).toContain("'cmd': { args: {}; options: {}; output: unknown }")
+  })
+
+  test('object keys that are not identifiers are quoted', () => {
+    const cli = Cli.create('test').command('cmd', {
+      options: z.object({
+        '1x': z.number(),
+        'foo-bar': z.string(),
+      }),
+      run: () => ({}),
+    })
+
+    const output = Typegen.fromCli(cli)
+    expect(output).toContain('"1x": number')
+    expect(output).toContain('"foo-bar": string')
+  })
+
+  test('unsupported schemas throw a clear typegen error', () => {
+    const cli = Cli.create('test').command('cmd', {
+      output: z.string().transform((value) => value.length),
+      run: () => 1,
+    })
+
+    expect(() => Typegen.fromCli(cli)).toThrow(
+      'Cannot generate TypeScript type for schema unsupported by JSON Schema',
+    )
+  })
+
+  test('skips commands that cannot be called by RPC client', () => {
+    const cli = Cli.create('test')
+      .command('deploy', {
+        aliases: ['ship'],
+        run: () => ({}),
+      })
+      .command('api', { fetch: () => new Response('ok') })
+
+    expect(Typegen.fromCli(cli)).toMatchInlineSnapshot(`
+      "/** Command map generated from your incur CLI. */
+      export type Commands = {
+        /** Generated command "deploy". */
+        'deploy': { args: {}; options: {} }
+      }
+
+      declare module 'incur' {
+        interface Register {
+          commands: Commands
+        }
+      }
+      "
+    `)
+  })
+
+  test('includes OpenAPI mounted operations without serving first', () => {
+    const cli = Cli.create('test').command('api', {
+      fetch: app.fetch,
+      openapi: spec,
+    })
+
+    const output = Typegen.fromCli(cli)
+    expect(output).toContain(
+      "'api getUser': { args: { id: number }; options: {}; output: { id: number; name: string; [key: string]: unknown } }",
+    )
+    expect(output).toContain(
+      "'api createUser': { args: {}; options: { name: string }; output: { created: boolean; name: string; [key: string]: unknown } }",
+    )
+    expect(output).not.toContain("'api': { args")
   })
 
   test('mixed top-level and grouped commands', () => {
@@ -191,12 +379,17 @@ describe('fromCli', () => {
     cli.command(pr)
 
     expect(Typegen.fromCli(cli)).toMatchInlineSnapshot(`
-      "declare module 'incur' {
+      "/** Command map generated from your incur CLI. */
+      export type Commands = {
+        /** Generated command "ping". */
+        'ping': { args: {}; options: {} }
+        /** Generated command "pr list". */
+        'pr list': { args: {}; options: {} }
+      }
+
+      declare module 'incur' {
         interface Register {
-          commands: {
-            'ping': { args: {}; options: {} }
-            'pr list': { args: {}; options: {} }
-          }
+          commands: Commands
         }
       }
       "

--- a/src/Typegen.test.ts
+++ b/src/Typegen.test.ts
@@ -355,6 +355,20 @@ describe('fromCli', () => {
     )
   })
 
+  test('streaming command', () => {
+    const cli = Cli.create('test').command('logs', {
+      output: z.object({ line: z.string() }),
+      async *run() {
+        yield { line: 'one' }
+      },
+    })
+
+    const output = Typegen.fromCli(cli)
+    expect(output).toContain(
+      '"logs": { args: {}; options: {}; output: { line: string }; stream: true }',
+    )
+  })
+
   test('skips commands that cannot be called by RPC client', () => {
     const cli = Cli.create('test')
       .command('deploy', {
@@ -558,6 +572,12 @@ function createClientRoundTripCli() {
       options: z.object({ token: z.string() }),
       output: z.void(),
       run: () => undefined,
+    })
+    .command('logs', {
+      output: z.object({ line: z.string() }),
+      async *run() {
+        yield { line: 'one' }
+      },
     })
     .command('api', {
       fetch: () => new Response(),

--- a/src/Typegen.ts
+++ b/src/Typegen.ts
@@ -25,8 +25,8 @@ export function fromCli(cli: Cli.Cli): string {
   for (const { name, args, options, output } of entries) {
     const outputType = output ? `; output: ${schemaToType(output, 'unknown')}` : ''
     lines.push(
-      `  /** Generated command ${JSON.stringify(name)}. */`,
-      `  '${name}': { args: ${schemaToType(args)}; options: ${schemaToType(options)}${outputType} }`,
+      `  /** Generated command ${commentText(JSON.stringify(name))}. */`,
+      `  ${JSON.stringify(name)}: { args: ${schemaToType(args)}; options: ${schemaToType(options)}${outputType} }`,
     )
   }
 
@@ -157,15 +157,21 @@ function resolveType(
       }
 
       const required = new Set((schema.required as string[] | undefined) ?? [])
-      const entries = Object.entries(properties).map(
-        ([key, value]) =>
-          `${propertyKey(key)}${required.has(key) ? '' : '?'}: ${propertyType(
-            resolveType(value, defs),
-            required.has(key),
-          )}`,
+      const entries = Object.entries(properties).map(([key, value]) => ({
+        key,
+        type: propertyType(resolveType(value, defs), required.has(key)),
+      }))
+      const props = entries.map(
+        ({ key, type }) => `${propertyKey(key)}${required.has(key) ? '' : '?'}: ${type}`,
       )
-      if (isSchema(additional)) entries.push(`[key: string]: ${resolveType(additional, defs)}`)
-      return `{ ${entries.join('; ')} }`
+      if (isSchema(additional))
+        props.push(
+          `[key: string]: ${unionType([
+            resolveType(additional, defs),
+            ...entries.map((entry) => entry.type),
+          ])}`,
+        )
+      return `{ ${props.join('; ')} }`
     }
     default:
       if ('not' in schema) return 'never'
@@ -175,6 +181,10 @@ function resolveType(
 
 function isSchema(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function commentText(value: string): string {
+  return value.replaceAll('*/', '*\\/')
 }
 
 function propertyKey(key: string): string {
@@ -189,4 +199,9 @@ function propertyNamesType(value: unknown, defs: Record<string, Record<string, u
 function propertyType(type: string, required: boolean): string {
   if (required || type.split(' | ').includes('undefined')) return type
   return `${type} | undefined`
+}
+
+function unionType(values: string[]): string {
+  const parts = [...new Set(values.flatMap((value) => value.split(' | ')))]
+  return parts.includes('unknown') ? 'unknown' : parts.join(' | ')
 }

--- a/src/Typegen.ts
+++ b/src/Typegen.ts
@@ -22,11 +22,12 @@ export function fromCli(cli: Cli.Cli): string {
     'export type Commands = {',
   ]
 
-  for (const { name, args, options, output } of entries) {
+  for (const { name, args, options, output, stream } of entries) {
     const outputType = output ? `; output: ${schemaToType(output, 'unknown')}` : ''
+    const streamType = stream ? '; stream: true' : ''
     lines.push(
       `  /** Generated command ${commentText(JSON.stringify(name))}. */`,
-      `  ${JSON.stringify(name)}: { args: ${schemaToType(args)}; options: ${schemaToType(options)}${outputType} }`,
+      `  ${JSON.stringify(name)}: { args: ${schemaToType(args)}; options: ${schemaToType(options)}${outputType}${streamType} }`,
     )
   }
 
@@ -56,6 +57,7 @@ function collectEntries(commands: Map<string, any>, prefix: string[]): Entry[] {
         args: entry.args,
         options: entry.options,
         output: entry.output,
+        stream: entry._stream,
       })
   }
   return result.sort((a, b) => a.name.localeCompare(b.name))
@@ -66,6 +68,7 @@ type Entry = {
   name: string
   options?: z.ZodObject<any> | undefined
   output?: z.ZodType | undefined
+  stream?: true | undefined
 }
 
 /** Converts a Zod schema to a TypeScript type string. Returns `fallback` for undefined schemas. */

--- a/src/Typegen.ts
+++ b/src/Typegen.ts
@@ -10,50 +10,92 @@ export async function generate(input: string, output: string): Promise<void> {
   await fs.writeFile(output, fromCli(cli))
 }
 
-/** Generates a `.d.ts` declaration string for the `incur` module augmentation. */
+/** Generates a `.ts` declaration string exporting an incur command map type and Register augmentation. */
 export function fromCli(cli: Cli.Cli): string {
   const commands = Cli.toCommands.get(cli)
   if (!commands) throw new Error('No commands registered on this CLI instance')
 
   const entries = collectEntries(commands, [])
 
-  const lines: string[] = ["declare module 'incur' {", '  interface Register {', '    commands: {']
+  const lines: string[] = [
+    '/** Command map generated from your incur CLI. */',
+    'export type Commands = {',
+  ]
 
-  for (const { name, args, options } of entries)
+  for (const { name, args, options, output } of entries) {
+    const outputType = output ? `; output: ${schemaToType(output, 'unknown')}` : ''
     lines.push(
-      `      '${name}': { args: ${schemaToType(args)}; options: ${schemaToType(options)} }`,
+      `  /** Generated command ${JSON.stringify(name)}. */`,
+      `  '${name}': { args: ${schemaToType(args)}; options: ${schemaToType(options)}${outputType} }`,
     )
+  }
 
-  lines.push('    }', '  }', '}', '')
+  lines.push(
+    '}',
+    '',
+    "declare module 'incur' {",
+    '  interface Register {',
+    '    commands: Commands',
+    '  }',
+    '}',
+    '',
+  )
   return lines.join('\n')
 }
 
 /** Recursively collects leaf commands with their full paths and schemas. */
-function collectEntries(
-  commands: Map<string, any>,
-  prefix: string[],
-): { name: string; args?: z.ZodObject<any>; options?: z.ZodObject<any> }[] {
+function collectEntries(commands: Map<string, any>, prefix: string[]): Entry[] {
   const result: ReturnType<typeof collectEntries> = []
   for (const [name, entry] of commands) {
+    if ('_alias' in entry || '_fetch' in entry) continue
     const path = [...prefix, name]
     if ('_group' in entry && entry._group) result.push(...collectEntries(entry.commands, path))
-    else result.push({ name: path.join(' '), args: entry.args, options: entry.options })
+    else
+      result.push({
+        name: path.join(' '),
+        args: entry.args,
+        options: entry.options,
+        output: entry.output,
+      })
   }
   return result.sort((a, b) => a.name.localeCompare(b.name))
 }
 
-/** Converts a Zod object schema to a TypeScript type string. Returns `{}` for undefined schemas. */
-function schemaToType(schema: z.ZodObject<any> | undefined): string {
-  if (!schema) return '{}'
-  const json = z.toJSONSchema(schema) as Record<string, unknown>
+type Entry = {
+  args?: z.ZodObject<any> | undefined
+  name: string
+  options?: z.ZodObject<any> | undefined
+  output?: z.ZodType | undefined
+}
+
+/** Converts a Zod schema to a TypeScript type string. Returns `fallback` for undefined schemas. */
+function schemaToType(schema: z.ZodType | undefined, fallback = '{}'): string {
+  if (!schema) return fallback
+
+  const kind = (schema as any)._def?.type
+  if (kind === 'void') return 'void'
+  if (kind === 'undefined') return 'undefined'
+
+  let json: Record<string, unknown>
+  try {
+    json = z.toJSONSchema(schema) as Record<string, unknown>
+  } catch (error) {
+    throw new TypegenError(
+      'Cannot generate TypeScript type for schema unsupported by JSON Schema',
+      {
+        cause: error,
+      },
+    )
+  }
+
   const defs = (json.$defs ?? {}) as Record<string, Record<string, unknown>>
-  const properties = json.properties as Record<string, Record<string, unknown>> | undefined
-  if (!properties || Object.keys(properties).length === 0) return '{}'
-  const required = new Set((json.required as string[] | undefined) ?? [])
-  const entries = Object.entries(properties).map(
-    ([key, value]) => `${key}${required.has(key) ? '' : '?'}: ${resolveType(value, defs)}`,
-  )
-  return `{ ${entries.join('; ')} }`
+  return resolveType(json, defs)
+}
+
+/** Error thrown when type generation cannot represent a schema. */
+class TypegenError extends Error {
+  /** Error class name. */
+  override name = 'Incur.TypegenError'
 }
 
 /** Recursively resolves a JSON Schema node to a TypeScript type string. */
@@ -90,20 +132,61 @@ function resolveType(
     case 'null':
       return 'null'
     case 'array': {
+      const prefixItems = schema.prefixItems as Record<string, unknown>[] | undefined
+      if (prefixItems) {
+        const items = schema.items as Record<string, unknown> | undefined
+        const entries = prefixItems.map((item) => resolveType(item, defs))
+        if (items) entries.push(`...${resolveType(items, defs)}[]`)
+        return `[${entries.join(', ')}]`
+      }
+
       const items = schema.items as Record<string, unknown> | undefined
       const itemType = items ? resolveType(items, defs) : 'unknown'
       return itemType.includes(' | ') ? `(${itemType})[]` : `${itemType}[]`
     }
     case 'object': {
       const properties = schema.properties as Record<string, Record<string, unknown>> | undefined
-      if (!properties || Object.keys(properties).length === 0) return '{}'
+      const additional = schema.additionalProperties
+      if (!properties || Object.keys(properties).length === 0) {
+        if (isSchema(additional))
+          return `Record<${propertyNamesType(schema.propertyNames, defs)}, ${resolveType(
+            additional,
+            defs,
+          )}>`
+        return '{}'
+      }
+
       const required = new Set((schema.required as string[] | undefined) ?? [])
       const entries = Object.entries(properties).map(
-        ([key, value]) => `${key}${required.has(key) ? '' : '?'}: ${resolveType(value, defs)}`,
+        ([key, value]) =>
+          `${propertyKey(key)}${required.has(key) ? '' : '?'}: ${propertyType(
+            resolveType(value, defs),
+            required.has(key),
+          )}`,
       )
+      if (isSchema(additional)) entries.push(`[key: string]: ${resolveType(additional, defs)}`)
       return `{ ${entries.join('; ')} }`
     }
     default:
+      if ('not' in schema) return 'never'
       return 'unknown'
   }
+}
+
+function isSchema(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function propertyKey(key: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(key) ? key : JSON.stringify(key)
+}
+
+function propertyNamesType(value: unknown, defs: Record<string, Record<string, unknown>>): string {
+  if (isSchema(value)) return resolveType(value, defs)
+  return 'string'
+}
+
+function propertyType(type: string, required: boolean): string {
+  if (required || type.split(' | ').includes('undefined')) return type
+  return `${type} | undefined`
 }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1637,15 +1637,15 @@ describe('typegen', () => {
         /** Generated command "slow". */
         "slow": { args: {}; options: {} }
         /** Generated command "stream". */
-        "stream": { args: {}; options: {} }
+        "stream": { args: {}; options: {}; stream: true }
         /** Generated command "stream-error". */
-        "stream-error": { args: {}; options: {} }
+        "stream-error": { args: {}; options: {}; stream: true }
         /** Generated command "stream-ok". */
-        "stream-ok": { args: {}; options: {} }
+        "stream-ok": { args: {}; options: {}; stream: true }
         /** Generated command "stream-text". */
-        "stream-text": { args: {}; options: {} }
+        "stream-text": { args: {}; options: {}; stream: true }
         /** Generated command "stream-throw". */
-        "stream-throw": { args: {}; options: {} }
+        "stream-throw": { args: {}; options: {}; stream: true }
         /** Generated command "validate-fail". */
         "validate-fail": { args: { email: string; age: number }; options: {} }
       }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1598,36 +1598,61 @@ describe('--llms', () => {
 })
 
 describe('typegen', () => {
-  test('generates correct .d.ts for entire CLI', () => {
+  test('generates correct command map type for entire CLI', () => {
     expect(Typegen.fromCli(createApp())).toMatchInlineSnapshot(`
-      "declare module 'incur' {
+      "/** Command map generated from your incur CLI. */
+      export type Commands = {
+        /** Generated command "auth login". */
+        'auth login': { args: {}; options: { hostname: string; web: boolean; scopes: string[] } }
+        /** Generated command "auth logout". */
+        'auth logout': { args: {}; options: {} }
+        /** Generated command "auth status". */
+        'auth status': { args: {}; options: {}; output: { loggedIn: boolean; hostname: string; user: string } }
+        /** Generated command "config". */
+        'config': { args: { key?: string | undefined }; options: {} }
+        /** Generated command "echo". */
+        'echo': { args: { message: string; repeat?: number | undefined }; options: { upper: boolean; prefix: string } }
+        /** Generated command "explode". */
+        'explode': { args: {}; options: {} }
+        /** Generated command "explode-clac". */
+        'explode-clac': { args: {}; options: {} }
+        /** Generated command "noop". */
+        'noop': { args: {}; options: {} }
+        /** Generated command "ping". */
+        'ping': { args: {}; options: {} }
+        /** Generated command "project create". */
+        'project create': { args: { name: string }; options: { description: string; private: boolean }; output: { id: string; url: string } }
+        /** Generated command "project delete". */
+        'project delete': { args: { id: string }; options: { force: boolean } }
+        /** Generated command "project deploy create". */
+        'project deploy create': { args: { env: string }; options: { branch: string; dryRun: boolean }; output: { deployId: string; url: string; status: string } }
+        /** Generated command "project deploy rollback". */
+        'project deploy rollback': { args: { deployId: string }; options: {} }
+        /** Generated command "project deploy status". */
+        'project deploy status': { args: { deployId: string }; options: {}; output: { deployId: string; status: string; progress: number } }
+        /** Generated command "project get". */
+        'project get': { args: { id: string }; options: {}; output: { id: string; name: string; description: string; members: { userId: string; role: string }[] } }
+        /** Generated command "project list". */
+        'project list': { args: {}; options: { limit: number; sort: "name" | "created" | "updated"; archived: boolean }; output: { items: { id: string; name: string; archived: boolean }[]; total: number } }
+        /** Generated command "slow". */
+        'slow': { args: {}; options: {} }
+        /** Generated command "stream". */
+        'stream': { args: {}; options: {} }
+        /** Generated command "stream-error". */
+        'stream-error': { args: {}; options: {} }
+        /** Generated command "stream-ok". */
+        'stream-ok': { args: {}; options: {} }
+        /** Generated command "stream-text". */
+        'stream-text': { args: {}; options: {} }
+        /** Generated command "stream-throw". */
+        'stream-throw': { args: {}; options: {} }
+        /** Generated command "validate-fail". */
+        'validate-fail': { args: { email: string; age: number }; options: {} }
+      }
+
+      declare module 'incur' {
         interface Register {
-          commands: {
-            'api': { args: {}; options: {} }
-            'auth login': { args: {}; options: { hostname: string; web: boolean; scopes: string[] } }
-            'auth logout': { args: {}; options: {} }
-            'auth status': { args: {}; options: {} }
-            'config': { args: { key?: string }; options: {} }
-            'echo': { args: { message: string; repeat?: number }; options: { upper: boolean; prefix: string } }
-            'explode': { args: {}; options: {} }
-            'explode-clac': { args: {}; options: {} }
-            'noop': { args: {}; options: {} }
-            'ping': { args: {}; options: {} }
-            'project create': { args: { name: string }; options: { description: string; private: boolean } }
-            'project delete': { args: { id: string }; options: { force: boolean } }
-            'project deploy create': { args: { env: string }; options: { branch: string; dryRun: boolean } }
-            'project deploy rollback': { args: { deployId: string }; options: {} }
-            'project deploy status': { args: { deployId: string }; options: {} }
-            'project get': { args: { id: string }; options: {} }
-            'project list': { args: {}; options: { limit: number; sort: "name" | "created" | "updated"; archived: boolean } }
-            'slow': { args: {}; options: {} }
-            'stream': { args: {}; options: {} }
-            'stream-error': { args: {}; options: {} }
-            'stream-ok': { args: {}; options: {} }
-            'stream-text': { args: {}; options: {} }
-            'stream-throw': { args: {}; options: {} }
-            'validate-fail': { args: { email: string; age: number }; options: {} }
-          }
+          commands: Commands
         }
       }
       "

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1603,51 +1603,51 @@ describe('typegen', () => {
       "/** Command map generated from your incur CLI. */
       export type Commands = {
         /** Generated command "auth login". */
-        'auth login': { args: {}; options: { hostname: string; web: boolean; scopes: string[] } }
+        "auth login": { args: {}; options: { hostname: string; web: boolean; scopes: string[] } }
         /** Generated command "auth logout". */
-        'auth logout': { args: {}; options: {} }
+        "auth logout": { args: {}; options: {} }
         /** Generated command "auth status". */
-        'auth status': { args: {}; options: {}; output: { loggedIn: boolean; hostname: string; user: string } }
+        "auth status": { args: {}; options: {}; output: { loggedIn: boolean; hostname: string; user: string } }
         /** Generated command "config". */
-        'config': { args: { key?: string | undefined }; options: {} }
+        "config": { args: { key?: string | undefined }; options: {} }
         /** Generated command "echo". */
-        'echo': { args: { message: string; repeat?: number | undefined }; options: { upper: boolean; prefix: string } }
+        "echo": { args: { message: string; repeat?: number | undefined }; options: { upper: boolean; prefix: string } }
         /** Generated command "explode". */
-        'explode': { args: {}; options: {} }
+        "explode": { args: {}; options: {} }
         /** Generated command "explode-clac". */
-        'explode-clac': { args: {}; options: {} }
+        "explode-clac": { args: {}; options: {} }
         /** Generated command "noop". */
-        'noop': { args: {}; options: {} }
+        "noop": { args: {}; options: {} }
         /** Generated command "ping". */
-        'ping': { args: {}; options: {} }
+        "ping": { args: {}; options: {} }
         /** Generated command "project create". */
-        'project create': { args: { name: string }; options: { description: string; private: boolean }; output: { id: string; url: string } }
+        "project create": { args: { name: string }; options: { description: string; private: boolean }; output: { id: string; url: string } }
         /** Generated command "project delete". */
-        'project delete': { args: { id: string }; options: { force: boolean } }
+        "project delete": { args: { id: string }; options: { force: boolean } }
         /** Generated command "project deploy create". */
-        'project deploy create': { args: { env: string }; options: { branch: string; dryRun: boolean }; output: { deployId: string; url: string; status: string } }
+        "project deploy create": { args: { env: string }; options: { branch: string; dryRun: boolean }; output: { deployId: string; url: string; status: string } }
         /** Generated command "project deploy rollback". */
-        'project deploy rollback': { args: { deployId: string }; options: {} }
+        "project deploy rollback": { args: { deployId: string }; options: {} }
         /** Generated command "project deploy status". */
-        'project deploy status': { args: { deployId: string }; options: {}; output: { deployId: string; status: string; progress: number } }
+        "project deploy status": { args: { deployId: string }; options: {}; output: { deployId: string; status: string; progress: number } }
         /** Generated command "project get". */
-        'project get': { args: { id: string }; options: {}; output: { id: string; name: string; description: string; members: { userId: string; role: string }[] } }
+        "project get": { args: { id: string }; options: {}; output: { id: string; name: string; description: string; members: { userId: string; role: string }[] } }
         /** Generated command "project list". */
-        'project list': { args: {}; options: { limit: number; sort: "name" | "created" | "updated"; archived: boolean }; output: { items: { id: string; name: string; archived: boolean }[]; total: number } }
+        "project list": { args: {}; options: { limit: number; sort: "name" | "created" | "updated"; archived: boolean }; output: { items: { id: string; name: string; archived: boolean }[]; total: number } }
         /** Generated command "slow". */
-        'slow': { args: {}; options: {} }
+        "slow": { args: {}; options: {} }
         /** Generated command "stream". */
-        'stream': { args: {}; options: {} }
+        "stream": { args: {}; options: {} }
         /** Generated command "stream-error". */
-        'stream-error': { args: {}; options: {} }
+        "stream-error": { args: {}; options: {} }
         /** Generated command "stream-ok". */
-        'stream-ok': { args: {}; options: {} }
+        "stream-ok": { args: {}; options: {} }
         /** Generated command "stream-text". */
-        'stream-text': { args: {}; options: {} }
+        "stream-text": { args: {}; options: {} }
         /** Generated command "stream-throw". */
-        'stream-throw': { args: {}; options: {} }
+        "stream-throw": { args: {}; options: {} }
         /** Generated command "validate-fail". */
-        'validate-fail': { args: { email: string; age: number }; options: {} }
+        "validate-fail": { args: { email: string; age: number }; options: {} }
       }
 
       declare module 'incur' {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { z } from 'zod'
+export { createClient } from './Client.js'
 export * as Cli from './Cli.js'
 export * as Completions from './Completions.js'
 export { default as middleware } from './middleware.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 export { z } from 'zod'
 export { createClient } from './Client.js'
+export { ClientError, isClientRpcError, isClientRpcErrorEnvelope } from './Errors.js'
+export type {
+  ClientRpcEnvelope,
+  ClientRpcError,
+  ClientRpcErrorEnvelope,
+  ClientRpcMeta,
+  ClientRpcSuccessEnvelope,
+} from './Errors.js'
 export * as Cli from './Cli.js'
 export * as Completions from './Completions.js'
 export { default as middleware } from './middleware.js'

--- a/src/internal/command.ts
+++ b/src/internal/command.ts
@@ -81,12 +81,12 @@ export async function execute(command: any, options: execute.Options): Promise<e
       // HTTP mode: positional args from URL path segments, options from body/query
       const parsed = Parser.parse(argv, { args: command.args })
       args = parsed.args
-      parsedOptions = command.options ? command.options.parse(inputOptions) : {}
+      parsedOptions = command.options ? Parser.zodParse(command.options, inputOptions) : {}
     } else {
       // MCP mode: all params come from inputOptions, split into args vs options
       const split = splitParams(inputOptions, command)
-      args = command.args ? command.args.parse(split.args) : {}
-      parsedOptions = command.options ? command.options.parse(split.options) : {}
+      args = command.args ? Parser.zodParse(command.args, split.args) : {}
+      parsedOptions = command.options ? Parser.zodParse(command.options, split.options) : {}
     }
 
     // Parse env

--- a/src/internal/command.ts
+++ b/src/internal/command.ts
@@ -82,11 +82,15 @@ export async function execute(command: any, options: execute.Options): Promise<e
       const parsed = Parser.parse(argv, { args: command.args })
       args = parsed.args
       parsedOptions = command.options ? Parser.zodParse(command.options, inputOptions) : {}
-    } else {
+    } else if (parseMode === 'flat') {
       // MCP mode: all params come from inputOptions, split into args vs options
       const split = splitParams(inputOptions, command)
       args = command.args ? Parser.zodParse(command.args, split.args) : {}
       parsedOptions = command.options ? Parser.zodParse(command.options, split.options) : {}
+    } else {
+      // RPC mode: args and options are already separated by the client
+      args = command.args ? Parser.zodParse(command.args, options.inputArgs ?? {}) : {}
+      parsedOptions = command.options ? Parser.zodParse(command.options, inputOptions) : {}
     }
 
     // Parse env
@@ -285,6 +289,8 @@ export declare namespace execute {
     format: string
     /** Whether the format was explicitly requested. */
     formatExplicit: boolean
+    /** Raw parsed args for structured RPC input. */
+    inputArgs?: Record<string, unknown> | undefined
     /** Raw parsed options (from query params, JSON body, or MCP params). For CLI, pass `{}`. */
     inputOptions: Record<string, unknown>
     /** Middleware handlers (root + group + command, already collected). */
@@ -296,8 +302,9 @@ export declare namespace execute {
      * - `'argv'` (default): parse both args and options from argv tokens (CLI mode)
      * - `'split'`: args from argv, options from inputOptions (HTTP mode)
      * - `'flat'`: all params from inputOptions, split by schema shapes (MCP mode)
+     * - `'structured'`: args from inputArgs, options from inputOptions (RPC mode)
      */
-    parseMode?: 'argv' | 'split' | 'flat' | undefined
+    parseMode?: 'argv' | 'split' | 'flat' | 'structured' | undefined
     /** The resolved command path. */
     path: string
     /** Vars schema for middleware variables. */


### PR DESCRIPTION
> [!WARNING]
> This PR is part of a stacked PR chain. Review/merge in order:
> #144
> #145
> #143
> **> #146**
> #147

## Overview

Adds streaming command support to the generated TypeScript client and structured RPC route.

## API

```ts
// Commands declared with `async *run` return typed async iterables.
const stream = await client('project logs')({
  args: { id: 'p1' },
})
//    ^? AsyncIterable<{ line: string }>

for await (const chunk of stream) {
  //             ^? { line: string }
  console.log(chunk.line)
}

// Non-streaming commands keep returning regular promise results.
const result = await client('project deploy')({
  args: { id: 'p1' },
})
//    ^? project deploy output
```

## Changes

- Detect async generator command handlers and emit `stream: true` metadata in typegen.
- Type streaming client calls as async iterables while preserving existing non-streaming call types.
- Add `application/x-ndjson` handling for RPC stream responses.
- Preserve returned CTA/error records from async generator RPC streams.
- Cancel the response body when consumers stop reading a stream early.

## Tests

- Adds client tests for NDJSON chunks, stream errors, malformed streams, missing completion records, and cancellation.
- Adds type tests for streaming command return inference.
- Adds typegen snapshot coverage for generated stream metadata.
- Adds RPC route coverage for async generator streams preserving returned CTA/error records.