### PR TITLE
feat: add openapi command naming config

### DIFF
--- a/.changeset/nice-openapi-modes.md
+++ b/.changeset/nice-openapi-modes.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Added `openapiConfig.mode` for choosing operation id or namespace command generation.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,25 @@ $ my-cli api createUser --name Bob
 # → name: Bob
 ```
 
+Set `openapiConfig.mode` to `'namespace'` to generate nested commands from path segments instead of using `operationId`:
+
+```ts
+Cli.create('my-cli', { description: 'My CLI' })
+  .command('api', { fetch: app.fetch, openapi: spec, openapiConfig: { mode: 'namespace' } })
+  .serve()
+```
+
+```sh
+$ my-cli api users --help
+# Commands:
+#   get   List users
+#   id    User ID
+#   post  Create a user
+
+$ my-cli api users get --limit 5
+# → users: ...
+```
+
 When served with `cli.fetch`, the generated spec is available at `/openapi.json`, `/openapi.yml`, `/openapi.yaml`, and `/.well-known/openapi.json`. Methods are inferred from command names: read-like commands use `GET`, update-like commands use `PATCH`, delete-like commands use `DELETE`, and other commands use `POST`.
 
 ### Serve CLIs as APIs

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -60,6 +60,13 @@ test('fetch command accepts OpenAPI object and URL sources', () => {
   cli.command('hostedApi', {
     fetch: Fetch.fromRequest('https://api.example.com'),
     openapi: 'openapi.json',
+    openapiConfig: { mode: 'namespace' },
+  })
+
+  cli.command('apiOperationMode', {
+    fetch,
+    openapi: { paths: {} },
+    openapiConfig: { mode: 'operation' },
   })
 })
 
@@ -67,17 +74,28 @@ test('root fetch accepts hosted request sources with OpenAPI paths', () => {
   Cli.create('test', {
     fetch: Fetch.fromRequest('https://api.example.com'),
     openapi: '/openapi.json',
+    openapiConfig: { mode: 'namespace' },
   })
 
   Cli.create('test', {
     fetch: Fetch.fromRequest(new URL('https://api.example.com')),
     openapi: new URL('https://api.example.com/openapi.json'),
+    openapiConfig: { mode: 'operation' },
   })
 
   Cli.create('test', {
     // @ts-expect-error -- hosted fetches must use Fetch.fromRequest.
     fetch: 'https://api.example.com',
     openapi: '/openapi.json',
+  })
+
+  Cli.create('test', {
+    fetch: Fetch.fromRequest('https://api.example.com'),
+    openapi: '/openapi.json',
+    openapiConfig: {
+      // @ts-expect-error -- OpenAPI mode must be namespace or operation.
+      mode: 'path',
+    },
   })
 })
 

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -82,6 +82,7 @@ export type Cli<
         description?: string | undefined
         fetch: FetchSource
         openapi?: Openapi.OpenAPISource | undefined
+        openapiConfig?: Openapi.Config | undefined
         outputPolicy?: OutputPolicy | undefined
       },
     ): Cli<commands, vars, env>
@@ -219,7 +220,9 @@ export function create(
     pending.push(
       (async () => {
         const spec = await Openapi.resolve(def.openapi, { baseUrl: rootFetchBaseUrl })
-        const generated = await Openapi.generateCommands(spec, rootFetch)
+        const generated = await Openapi.generateCommands(spec, rootFetch, {
+          config: def.openapiConfig,
+        })
         for (const [name, command] of generated) commands.set(name, command)
       })(),
     )
@@ -244,6 +247,7 @@ export function create(
                 })
                 const generated = await Openapi.generateCommands(spec, fetch, {
                   basePath: def.basePath,
+                  config: def.openapiConfig,
                 })
                 commands.set(nameOrCli, {
                   _group: true,
@@ -386,6 +390,8 @@ export declare namespace create {
     fetch?: FetchSource | undefined
     /** OpenAPI spec source used to generate typed root commands for the root fetch handler. */
     openapi?: Openapi.OpenAPISource | undefined
+    /** Configuration for generated OpenAPI commands. */
+    openapiConfig?: Openapi.Config | undefined
     /** Default output format. Overridden by `--format` or `--json`. */
     format?: Formatter.Format | undefined
     /** Zod schema for named options/flags. */

--- a/src/Openapi.test.ts
+++ b/src/Openapi.test.ts
@@ -159,6 +159,38 @@ describe('generateCommands', () => {
     const limitSchema = cmd.options!.shape.limit
     expect(limitSchema.description).toBe('Max results')
   })
+
+  test('generates namespace command groups from paths', async () => {
+    const commands = await Openapi.generateCommands(spec, app.fetch, {
+      config: { mode: 'namespace' },
+    })
+    expect([...commands.keys()].sort()).toMatchInlineSnapshot(`
+      [
+        "health",
+        "users",
+      ]
+    `)
+
+    const users = commands.get('users')!
+    expect('_group' in users).toMatchInlineSnapshot(`true`)
+    expect('_group' in users ? users.description : undefined).toMatchInlineSnapshot(`"List users"`)
+    expect('_group' in users ? [...users.commands.keys()].sort() : []).toMatchInlineSnapshot(`
+      [
+        "get",
+        "id",
+        "post",
+      ]
+    `)
+
+    const id = '_group' in users ? users.commands.get('id')! : undefined
+    expect(id && '_group' in id ? id.description : undefined).toMatchInlineSnapshot(`"User ID"`)
+    expect(id && '_group' in id ? [...id.commands.keys()].sort() : []).toMatchInlineSnapshot(`
+      [
+        "delete",
+        "get",
+      ]
+    `)
+  })
 })
 
 describe('cli integration', () => {
@@ -172,6 +204,16 @@ describe('cli integration', () => {
   test('GET /users via operationId', async () => {
     const { output } = await serve(createCli(), ['api', 'listUsers'])
     expect(output).toContain('Alice')
+  })
+
+  test('GET /users via namespace', async () => {
+    const cli = Cli.create('test', { description: 'test' }).command('api', {
+      fetch: app.fetch,
+      openapi: spec,
+      openapiConfig: { mode: 'namespace' },
+    })
+    const { output } = await serve(cli, ['api', 'users', 'get', '--limit', '5', '--format', 'json'])
+    expect(json(output).limit).toMatchInlineSnapshot(`5`)
   })
 
   test('GET /users?limit=5 via options', async () => {

--- a/src/Openapi.test.ts
+++ b/src/Openapi.test.ts
@@ -150,12 +150,14 @@ describe('generateCommands', () => {
   test('command has description from summary', async () => {
     const commands = await Openapi.generateCommands(spec, app.fetch)
     const cmd = commands.get('listUsers')!
+    if ('_group' in cmd) throw new Error('expected listUsers command')
     expect(cmd.description).toBe('List users')
   })
 
   test('coerced number params preserve description', async () => {
     const commands = await Openapi.generateCommands(spec, app.fetch)
     const cmd = commands.get('listUsers')!
+    if ('_group' in cmd) throw new Error('expected listUsers command')
     const limitSchema = cmd.options!.shape.limit
     expect(limitSchema.description).toBe('Max results')
   })

--- a/src/Openapi.ts
+++ b/src/Openapi.ts
@@ -17,6 +17,15 @@ export type OpenAPISpec = { paths?: {} | undefined }
 /** OpenAPI document source accepted by fetch-backed CLI commands. */
 export type OpenAPISource = OpenAPISpec | string | URL
 
+/** Strategy used to name commands generated from OpenAPI operations. */
+export type Mode = 'namespace' | 'operation'
+
+/** Configuration for generating commands from an OpenAPI document. */
+export type Config = {
+  /** Command naming strategy. Defaults to `'operation'`. */
+  mode?: Mode | undefined
+}
+
 /** Options for generating an OpenAPI document from an incur CLI. */
 export type GenerateOptions = {
   /** API description. Defaults to the CLI description. */
@@ -88,6 +97,25 @@ type GeneratedCommand = {
   description?: string | undefined
   options?: z.ZodObject<any> | undefined
   run: (context: any) => any
+}
+
+type GeneratedEntry = GeneratedCommand | GeneratedGroup
+
+type GeneratedGroup = {
+  _group: true
+  description?: string | undefined
+  commands: Map<string, GeneratedEntry>
+}
+
+type CommandSegment = {
+  description?: string | undefined
+  name: string
+}
+
+type OperationEntry = {
+  method: string
+  operation: Operation
+  path: string
 }
 
 function addEntry(paths: NonNullable<Document['paths']>, segments: string[], entry: any) {
@@ -307,72 +335,220 @@ function resolveUrl(source: string | URL, baseUrl: string | URL | undefined) {
 export async function generateCommands(
   spec: OpenAPISpec,
   fetch: FetchHandler,
-  options: { basePath?: string | undefined } = {},
-): Promise<Map<string, GeneratedCommand>> {
+  options: generateCommands.Options = {},
+): Promise<Map<string, GeneratedEntry>> {
   const resolved = dereference(structuredClone(spec)) as OpenAPISpec
-  const commands = new Map<string, GeneratedCommand>()
+  const commands = new Map<string, GeneratedEntry>()
   const paths = (resolved.paths ?? {}) as Record<string, Record<string, unknown>>
+  const operations = openapiOperations(paths)
+  const namespaceInfo = getNamespaceInfo(operations)
+  const { config } = options
 
-  for (const [path, methods] of Object.entries(paths)) {
-    for (const [method, operation] of Object.entries(methods)) {
-      if (method.startsWith('x-')) continue
-      const op = operation as Operation
-      const name = op.operationId ?? `${method}_${path.replace(/[/{}]/g, '_')}`
-      const httpMethod = method.toUpperCase()
+  for (const { method, operation: op, path } of operations) {
+    const segments = commandSegments({
+      method,
+      mode: config?.mode ?? 'operation',
+      namespaceInfo,
+      operation: op,
+      path,
+    })
+    const httpMethod = method.toUpperCase()
 
-      const pathParams = (op.parameters ?? []).filter((p) => p.in === 'path')
-      const queryParams = (op.parameters ?? []).filter((p) => p.in === 'query')
+    const pathParams = (op.parameters ?? []).filter((p) => p.in === 'path')
+    const queryParams = (op.parameters ?? []).filter((p) => p.in === 'query')
 
-      const bodySchema = op.requestBody?.content?.['application/json']?.schema
-      const bodyProps = (bodySchema?.properties ?? {}) as Record<string, Record<string, unknown>>
-      const bodyRequired = new Set((bodySchema?.required as string[]) ?? [])
+    const bodySchema = op.requestBody?.content?.['application/json']?.schema
+    const bodyProps = (bodySchema?.properties ?? {}) as Record<string, Record<string, unknown>>
+    const bodyRequired = new Set((bodySchema?.required as string[]) ?? [])
 
-      // Build args Zod schema from path params
-      let argsSchema: z.ZodObject<any> | undefined
-      if (pathParams.length > 0) {
-        const shape: Record<string, z.ZodType> = {}
-        for (const p of pathParams) {
-          let zodType = p.schema ? toZod(p.schema) : z.string()
-          if (p.description) zodType = zodType.describe(p.description)
-          // Path params need coercion from string argv
-          shape[p.name] = coerceIfNeeded(zodType)
-        }
-        argsSchema = z.object(shape)
-      }
-
-      // Build options Zod schema from query params + body properties
-      const optShape: Record<string, z.ZodType> = {}
-      for (const p of queryParams) {
+    // Build args Zod schema from path params
+    let argsSchema: z.ZodObject<any> | undefined
+    if (pathParams.length > 0) {
+      const shape: Record<string, z.ZodType> = {}
+      for (const p of pathParams) {
         let zodType = p.schema ? toZod(p.schema) : z.string()
-        if (!p.required) zodType = zodType.optional()
         if (p.description) zodType = zodType.describe(p.description)
-        optShape[p.name] = coerceIfNeeded(zodType)
+        // Path params need coercion from string argv
+        shape[p.name] = coerceIfNeeded(zodType)
       }
-      for (const [key, schema] of Object.entries(bodyProps)) {
-        let zodType = toZod(schema)
-        if (!bodyRequired.has(key)) zodType = zodType.optional()
-        optShape[key] = zodType
-      }
-      const optionsSchema = Object.keys(optShape).length > 0 ? z.object(optShape) : undefined
-
-      commands.set(name, {
-        description: op.summary ?? op.description,
-        args: argsSchema,
-        options: optionsSchema,
-        run: createHandler({
-          basePath: options.basePath,
-          fetch,
-          httpMethod,
-          path,
-          pathParams,
-          queryParams,
-          bodyProps,
-        }),
-      })
+      argsSchema = z.object(shape)
     }
+
+    // Build options Zod schema from query params + body properties
+    const optShape: Record<string, z.ZodType> = {}
+    for (const p of queryParams) {
+      let zodType = p.schema ? toZod(p.schema) : z.string()
+      if (!p.required) zodType = zodType.optional()
+      if (p.description) zodType = zodType.describe(p.description)
+      optShape[p.name] = coerceIfNeeded(zodType)
+    }
+    for (const [key, schema] of Object.entries(bodyProps)) {
+      let zodType = toZod(schema)
+      if (!bodyRequired.has(key)) zodType = zodType.optional()
+      optShape[key] = zodType
+    }
+    const optionsSchema = Object.keys(optShape).length > 0 ? z.object(optShape) : undefined
+
+    setCommand(commands, segments, {
+      description: op.summary ?? op.description,
+      args: argsSchema,
+      options: optionsSchema,
+      run: createHandler({
+        basePath: options.basePath,
+        fetch,
+        httpMethod,
+        path,
+        pathParams,
+        queryParams,
+        bodyProps,
+      }),
+    })
   }
 
   return commands
+}
+
+export declare namespace generateCommands {
+  /** Options for generating incur commands from an OpenAPI spec. */
+  type Options = {
+    /** Base path prepended to generated request paths. */
+    basePath?: string | undefined
+    /** Configuration for generated OpenAPI commands. */
+    config?: Config | undefined
+  }
+}
+
+const openapiMethods = new Set([
+  'delete',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+  'trace',
+])
+
+function openapiOperations(paths: Record<string, Record<string, unknown>>) {
+  const operations: OperationEntry[] = []
+  for (const [path, methods] of Object.entries(paths))
+    for (const [method, operation] of Object.entries(methods))
+      if (openapiMethods.has(method))
+        operations.push({ method, operation: operation as Operation, path })
+  return operations
+}
+
+function getNamespaceInfo(operations: OperationEntry[]) {
+  const pathOperations = new Map<string, number>()
+  const parentPaths = new Set<string>()
+
+  for (const { path } of operations) {
+    pathOperations.set(path, (pathOperations.get(path) ?? 0) + 1)
+
+    const segments = namespaceNames(path)
+    for (let i = 1; i < segments.length; i++) parentPaths.add(`/${segments.slice(0, i).join('/')}`)
+  }
+
+  return { parentPaths, pathOperations }
+}
+
+function commandSegments(options: commandSegments.Options) {
+  const { method, mode, namespaceInfo, operation, path } = options
+  if (mode === 'operation')
+    return [{ name: operation.operationId ?? `${method}_${path.replace(/[/{}]/g, '_')}` }]
+
+  const segments = namespaceSegments(path, operation)
+  const needsMethod =
+    segments.length === 0 ||
+    namespaceInfo.parentPaths.has(namespacePath(path)) ||
+    (namespaceInfo.pathOperations.get(path) ?? 0) > 1
+  const describedSegments = describeNamespaceLeaf(
+    segments,
+    operation.summary ?? operation.description,
+  )
+  return [
+    ...(describedSegments.length > 0 ? describedSegments : [{ name: 'root' }]),
+    ...(needsMethod ? [{ name: method }] : []),
+  ]
+}
+
+declare namespace commandSegments {
+  type Options = {
+    method: string
+    mode: Mode
+    namespaceInfo: {
+      parentPaths: Set<string>
+      pathOperations: Map<string, number>
+    }
+    operation: Operation
+    path: string
+  }
+}
+
+function namespaceSegments(path: string, operation?: Operation | undefined) {
+  return path
+    .split('/')
+    .map((segment) => namespaceSegment(segment, operation))
+    .filter((segment): segment is CommandSegment => segment !== undefined)
+}
+
+function namespaceNames(path: string) {
+  return namespaceSegments(path).map((segment) => segment.name)
+}
+
+function namespacePath(path: string) {
+  return `/${namespaceNames(path).join('/')}`
+}
+
+function namespaceSegment(segment: string, operation?: Operation | undefined) {
+  if (!segment) return undefined
+  const name = segment.startsWith('{') && segment.endsWith('}') ? segment.slice(1, -1) : segment
+  const description = operation?.parameters?.find(
+    (parameter) => parameter.in === 'path' && parameter.name === name,
+  )?.description
+  return {
+    ...(description ? { description } : undefined),
+    name: name.replace(/[^\w.-]+/g, '-'),
+  }
+}
+
+function describeNamespaceLeaf(segments: CommandSegment[], description: string | undefined) {
+  if (!description || segments.length === 0) return segments
+  return segments.map((segment, index) =>
+    index === segments.length - 1 && !segment.description ? { ...segment, description } : segment,
+  )
+}
+
+function setCommand(
+  commands: Map<string, GeneratedEntry>,
+  segments: CommandSegment[],
+  command: GeneratedCommand,
+) {
+  const [head, ...tail] = segments
+  if (!head) return
+  if (tail.length === 0) {
+    commands.set(head.name, command)
+    return
+  }
+
+  const group = getGroup(commands, head)
+  setCommand(group.commands, tail, command)
+}
+
+function getGroup(commands: Map<string, GeneratedEntry>, segment: CommandSegment) {
+  const existing = commands.get(segment.name)
+  if (existing && '_group' in existing) {
+    if (!existing.description && segment.description) existing.description = segment.description
+    return existing
+  }
+
+  const group: GeneratedGroup = {
+    _group: true,
+    commands: new Map(),
+    ...(segment.description ? { description: segment.description } : undefined),
+  }
+  commands.set(segment.name, group)
+  return group
 }
 
 function createHandler(config: {

--- a/src/Openapi.ts
+++ b/src/Openapi.ts
@@ -452,7 +452,7 @@ function getNamespaceInfo(operations: OperationEntry[]) {
   return { parentPaths, pathOperations }
 }
 
-function commandSegments(options: commandSegments.Options) {
+function commandSegments(options: commandSegments.Options): CommandSegment[] {
   const { method, mode, namespaceInfo, operation, path } = options
   if (mode === 'operation')
     return [{ name: operation.operationId ?? `${method}_${path.replace(/[/{}]/g, '_')}` }]
@@ -485,11 +485,11 @@ declare namespace commandSegments {
   }
 }
 
-function namespaceSegments(path: string, operation?: Operation | undefined) {
+function namespaceSegments(path: string, operation?: Operation | undefined): CommandSegment[] {
   return path
     .split('/')
     .map((segment) => namespaceSegment(segment, operation))
-    .filter((segment): segment is CommandSegment => segment !== undefined)
+    .filter(isCommandSegment)
 }
 
 function namespaceNames(path: string) {
@@ -500,7 +500,10 @@ function namespacePath(path: string) {
   return `/${namespaceNames(path).join('/')}`
 }
 
-function namespaceSegment(segment: string, operation?: Operation | undefined) {
+function namespaceSegment(
+  segment: string,
+  operation?: Operation | undefined,
+): CommandSegment | undefined {
   if (!segment) return undefined
   const name = segment.startsWith('{') && segment.endsWith('}') ? segment.slice(1, -1) : segment
   const description = operation?.parameters?.find(
@@ -512,7 +515,14 @@ function namespaceSegment(segment: string, operation?: Operation | undefined) {
   }
 }
 
-function describeNamespaceLeaf(segments: CommandSegment[], description: string | undefined) {
+function isCommandSegment(segment: CommandSegment | undefined): segment is CommandSegment {
+  return segment !== undefined
+}
+
+function describeNamespaceLeaf(
+  segments: CommandSegment[],
+  description: string | undefined,
+): CommandSegment[] {
   if (!description || segments.length === 0) return segments
   return segments.map((segment, index) =>
     index === segments.length - 1 && !segment.description ? { ...segment, description } : segment,

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -2495,6 +2495,107 @@ describe('hosted OpenAPI CLI', () => {
       fetch.mockRestore()
     }
   })
+
+  test('namespace mode help renders path-derived command groups', async () => {
+    const fetch = hostedOpenapiFetch()
+    const cli = Cli.create('test', {
+      fetch: Fetch.fromRequest('https://api.example.com/api'),
+      openapi: 'openapi.json',
+      openapiConfig: { mode: 'namespace' },
+    })
+
+    try {
+      const { output } = await serve(cli, ['--help'])
+      expect(output).toMatchInlineSnapshot(`
+        "test
+
+        Usage: test <command>
+
+        Commands:
+          health  Health check
+          users   List users
+
+        Integrations:
+          completions  Generate shell completion script
+          mcp add      Register as MCP server
+          skills       Sync skill files to agents (add, list)
+
+        Global Options:
+          --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
+          --format <toon|json|yaml|md|jsonl>  Output format
+          --full-output                       Show full output envelope
+          --help                              Show help
+          --llms, --llms-full                 Print LLM-readable manifest
+          --mcp                               Start as MCP stdio server
+          --schema                            Show JSON Schema for command
+          --token-count                       Print token count of output (instead of output)
+          --token-limit <n>                   Limit output to n tokens
+          --token-offset <n>                  Skip first n tokens of output
+          --version                           Show version
+        "
+      `)
+    } finally {
+      fetch.mockRestore()
+    }
+  })
+
+  test('namespace mode group help renders path-derived subcommands', async () => {
+    const fetch = hostedOpenapiFetch()
+    const cli = Cli.create('test', {
+      fetch: Fetch.fromRequest('https://api.example.com/api'),
+      openapi: 'openapi.json',
+      openapiConfig: { mode: 'namespace' },
+    })
+
+    try {
+      const { output } = await serve(cli, ['users', '--help'])
+      expect(output).toMatchInlineSnapshot(`
+        "test users — List users
+
+        Usage: test users <command>
+
+        Commands:
+          get   List users
+          id    User ID
+          post  Create a user
+
+        Global Options:
+          --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])
+          --format <toon|json|yaml|md|jsonl>  Output format
+          --full-output                       Show full output envelope
+          --help                              Show help
+          --llms, --llms-full                 Print LLM-readable manifest
+          --schema                            Show JSON Schema for command
+          --token-count                       Print token count of output (instead of output)
+          --token-limit <n>                   Limit output to n tokens
+          --token-offset <n>                  Skip first n tokens of output
+        "
+      `)
+    } finally {
+      fetch.mockRestore()
+    }
+  })
+
+  test('namespace mode runs path-derived subcommands', async () => {
+    const fetch = hostedOpenapiFetch()
+    const cli = Cli.create('test', {
+      fetch: Fetch.fromRequest('https://api.example.com/api'),
+      openapi: 'openapi.json',
+      openapiConfig: { mode: 'namespace' },
+    })
+
+    try {
+      const { output } = await serve(cli, ['users', 'get', '--limit', '5'])
+      expect(output).toMatchInlineSnapshot(`
+        "users[1]{id,name}:
+          1,Alice
+        limit: 5
+        "
+      `)
+    } finally {
+      fetch.mockRestore()
+    }
+  })
 })
 
 async function fetchJson(cli: Cli.Cli<any, any, any>, req: Request) {


### PR DESCRIPTION
Adds `openapiConfig.mode` for choosing how OpenAPI-backed commands are named. The default keeps operation id command generation, while `namespace` mode builds nested command groups from OpenAPI path segments.

Namespace groups inherit descriptions from operation summaries and path parameter metadata, so help output stays useful at each generated level.
