### PR TITLE
fix: avoid duplicate group prefix in scoped `--llms` output

### DIFF
--- a/.changeset/scoped-llms-duplicate-prefix.md
+++ b/.changeset/scoped-llms-duplicate-prefix.md
@@ -1,0 +1,7 @@
+---
+'incur': patch
+---
+
+Fixed `--llms` and `--llms-full` markdown output when scoped to a command group (e.g. `cli auth --llms`) to no longer duplicate the group prefix in command signatures (`cli auth auth login` → `cli auth login`).
+
+The scoped name already carries the prefix, so command collection now runs with an empty prefix to match the unscoped and JSON/YAML manifest output.

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -1385,8 +1385,11 @@ describe('--llms', () => {
     cli.command('ping', { description: 'Health check', run: () => ({}) })
 
     const { output } = await serve(cli, ['auth', '--llms'])
-    expect(output).toContain('test auth auth login')
-    expect(output).toContain('test auth auth logout')
+    expect(output).toContain('test auth login')
+    expect(output).toContain('test auth logout')
+    // The scoped prefix must not be duplicated in the command signature.
+    expect(output).not.toContain('test auth auth login')
+    expect(output).not.toContain('test auth auth logout')
     expect(output).not.toContain('ping')
   })
 

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -634,7 +634,9 @@ async function serveImpl(
     if (llmsFull) {
       if (!formatExplicit || formatFlag === 'md') {
         const groups = new Map<string, string>()
-        const cmds = collectSkillCommands(scopedCommands, prefix, groups, scopedRoot)
+        // Command names are relative to the scope; `scopedName` already carries
+        // the prefix, so pass `[]` to avoid prepending it twice.
+        const cmds = collectSkillCommands(scopedCommands, [], groups, scopedRoot)
         const scopedName = prefix.length > 0 ? `${name} ${prefix.join(' ')}` : name
         writeln(Skill.generate(scopedName, cmds, groups))
         return
@@ -645,7 +647,9 @@ async function serveImpl(
 
     if (!formatExplicit || formatFlag === 'md') {
       const groups = new Map<string, string>()
-      const cmds = collectSkillCommands(scopedCommands, prefix, groups, scopedRoot)
+      // Command names are relative to the scope; `scopedName` already carries
+      // the prefix, so pass `[]` to avoid prepending it twice.
+      const cmds = collectSkillCommands(scopedCommands, [], groups, scopedRoot)
       const scopedName = prefix.length > 0 ? `${name} ${prefix.join(' ')}` : name
       writeln(Skill.index(scopedName, cmds, scopedDescription))
       return

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1513,9 +1513,9 @@ describe('--llms', () => {
 
       | Command | Description |
       |---------|-------------|
-      | \`app auth auth login\` | Log in to the service |
-      | \`app auth auth logout\` | Log out of the service |
-      | \`app auth auth status\` | Show authentication status |
+      | \`app auth login\` | Log in to the service |
+      | \`app auth logout\` | Log out of the service |
+      | \`app auth status\` | Show authentication status |
 
       Run \`app auth --llms-full\` for full manifest. Run \`app auth <command> --schema\` for argument details.
       "
@@ -1531,9 +1531,9 @@ describe('--llms', () => {
 
       | Command | Description |
       |---------|-------------|
-      | \`app project deploy project deploy create <env>\` | Create a deployment |
-      | \`app project deploy project deploy rollback <deployId>\` | Rollback a deployment |
-      | \`app project deploy project deploy status <deployId>\` | Check deployment status |
+      | \`app project deploy create <env>\` | Create a deployment |
+      | \`app project deploy rollback <deployId>\` | Rollback a deployment |
+      | \`app project deploy status <deployId>\` | Check deployment status |
 
       Run \`app project deploy --llms-full\` for full manifest. Run \`app project deploy <command> --schema\` for argument details.
       "


### PR DESCRIPTION
## Problem

When `--llms` / `--llms-full` (markdown) is scoped to a command group, the group prefix is applied twice — producing command signatures like:

```
$ cli auth --llms
| `cli auth auth login`  | ... |
| `cli auth auth logout` | ... |
```

instead of the correct `cli auth login`. This affects every group, whether built as a sub-`Cli` or generated from an OpenAPI spec, and shows up in both `--llms` and `--llms-full`.

## Root cause

In the scoped `--llms` markdown branches, the prefix is double-counted: it's folded into `scopedName` **and** passed into `collectSkillCommands`, which bakes it into each `cmd.name` (`path = [...prefix, name]`). `Skill.index`/`Skill.generate` then render `${scopedName} ${cmd.name}`.

The unscoped call sites (and the JSON/YAML manifest path, which doesn't prepend `scopedName`) already pass `[]`, which is why root `cli --llms` and `--format json` were correct.

## Fix

Pass `[]` to `collectSkillCommands` in the two scoped markdown branches so command names stay relative to the already-prefixed `scopedName`.

## Tests

- Updated `Cli.test.ts` `scopes to subtree` — it previously **asserted the buggy** `test auth auth login` output (which is why this slipped through). It now asserts `test auth login` plus negative assertions against the duplicated form.
- Regenerated the two `e2e.test.ts` inline snapshots that had captured the doubled output.
- Full suite green, lint + types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)