### PR TITLE
perf: lazy-load yaml and the MCP SDK off the command-run hot path

### DIFF
--- a/.changeset/lazy-optional-deps.md
+++ b/.changeset/lazy-optional-deps.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Lazy-loaded YAML and MCP SDK imports outside plain command runs.

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -2,7 +2,6 @@ import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { estimateTokenCount, sliceByTokens } from 'tokenx'
-import { parse as yamlParse, stringify as yamlStringify } from 'yaml'
 import { z } from 'zod'
 
 import * as Completions from './Completions.js'
@@ -24,6 +23,7 @@ import * as Command from './internal/command.js'
 import { isRecord, suggest, toKebab } from './internal/helpers.js'
 import { detectRunner } from './internal/pm.js'
 import type { OneOf } from './internal/types.js'
+import * as Yaml from './internal/yaml.js'
 import * as Mcp from './Mcp.js'
 import type { Context as MiddlewareContext, Handler as MiddlewareHandler } from './middleware.js'
 import * as Openapi from './Openapi.js'
@@ -533,6 +533,9 @@ async function serveImpl(
     configDisabled,
     rest: filtered,
   } = builtinFlags
+
+  // Pre-load yaml for the sync formatting paths below (yaml is loaded lazily — see internal/yaml.ts).
+  if (formatFlag === 'yaml') await Yaml.load()
 
   // --mcp: start as MCP stdio server
   if (mcpFlag) {
@@ -1124,6 +1127,7 @@ async function serveImpl(
   // Resolve effective format: explicit --format/--json → command default → CLI default → toon
   const resolvedFormat = 'command' in resolved && (resolved as any).command.format
   const format = formatExplicit ? formatFlag : resolvedFormat || options.format || 'toon'
+  if (format === 'yaml') await Yaml.load()
 
   // Fall back to root fetch/command when no subcommand matches,
   // but only if the token doesn't look like a typo of a known command.
@@ -1677,7 +1681,7 @@ async function fetchImpl(
   if (req.method === 'GET' && isOpenapiRoute(segments)) {
     const spec = generatedOpenapi(name, commands, options)
     const yaml = segments[0] === 'openapi.yml' || segments[0] === 'openapi.yaml'
-    return new Response(yaml ? yamlStringify(spec) : JSON.stringify(spec), {
+    return new Response(yaml ? (await Yaml.load()).stringify(spec) : JSON.stringify(spec), {
       status: 200,
       headers: {
         'content-type': yaml ? 'application/yaml' : 'application/json',
@@ -1701,6 +1705,8 @@ async function fetchImpl(
     segments.length >= 3 &&
     req.method === 'GET'
   ) {
+    // Pre-load yaml for the sync call paths below (`Skill.split`, frontmatter parsing).
+    await Yaml.load()
     const groups = new Map<string, string>()
     const cmds = collectSkillCommands(commands, [], groups, options.rootCommand)
 
@@ -1709,7 +1715,7 @@ async function fetchImpl(
       const files = Skill.split(name, cmds, 1, groups)
       const skills = files.map((f) => {
         const fmMatch = f.content.match(/^---\n([\s\S]*?)\n---/)
-        const meta = fmMatch ? (yamlParse(fmMatch[1]!) as Record<string, string>) : {}
+        const meta = fmMatch ? (Yaml.loadSync().parse(fmMatch[1]!) as Record<string, string>) : {}
         return {
           name: f.dir || name,
           description: meta.description ?? '',

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -1,5 +1,6 @@
 import { encode } from '@toon-format/toon'
-import { stringify as yamlStringify } from 'yaml'
+
+import * as Yaml from './internal/yaml.js'
 
 /** Supported output formats. */
 export type Format = 'toon' | 'json' | 'yaml' | 'md' | 'jsonl'
@@ -18,7 +19,7 @@ export function format(value: unknown, fmt: Format = 'toon'): string {
     }
     return JSON.stringify(value, null, 2)
   }
-  if (fmt === 'yaml') return yamlStringify(value)
+  if (fmt === 'yaml') return Yaml.loadSync().stringify(value)
   if (fmt === 'md') return formatMarkdown(value)
   if (fmt === 'jsonl') {
     if (Array.isArray(value)) return value.map((v) => JSON.stringify(v)).join('\n')

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -1,4 +1,3 @@
-import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server'
 import type { Readable, Writable } from 'node:stream'
 import { z } from 'zod'
 
@@ -13,6 +12,9 @@ export async function serve(
   commands: Map<string, any>,
   options: serve.Options = {},
 ): Promise<void> {
+  // Lazy: only runs when actually serving MCP, so plain command runs don't pay for the SDK import.
+  const { McpServer, StdioServerTransport } = await import('@modelcontextprotocol/server')
+
   const server = new McpServer({ name, version })
 
   for (const tool of collectTools(commands, [])) {

--- a/src/Skill.ts
+++ b/src/Skill.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
-import { stringify as yamlStringify } from 'yaml'
 import type { z } from 'zod'
 
+import * as Yaml from './internal/yaml.js'
 import * as Schema from './Schema.js'
 
 /** Information about a single command, passed to `generate()`. */
@@ -137,10 +137,12 @@ function renderGroup(
     ? `${desc.replace(/\.$/, '')}. Run \`${title} --help\` for usage details.`
     : `Run \`${title} --help\` for usage details.`
 
-  const fm = yamlStringify(
-    { name: slugify(title), description, requires_bin: cli, command: title },
-    { lineWidth: 0 },
-  ).trimEnd()
+  const fm = Yaml.loadSync()
+    .stringify(
+      { name: slugify(title), description, requires_bin: cli, command: title },
+      { lineWidth: 0 },
+    )
+    .trimEnd()
   const fmBlock = `---\n${fm}\n---`
 
   const body = cmds.map((cmd) => renderCommandBody(cli, cmd)).join('\n\n---\n\n')

--- a/src/Skillgen.ts
+++ b/src/Skillgen.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import * as Cli from './Cli.js'
 import { importCli } from './internal/utils.js'
+import * as Yaml from './internal/yaml.js'
 import * as Skill from './Skill.js'
 
 /** Imports a CLI from `input`, generates Markdown skill files, and writes them to `output`. */
@@ -14,6 +15,8 @@ export async function generate(input: string, output: string, depth = 1): Promis
   const groups = new Map<string, string>()
   if (cli.description) groups.set(cli.name, cli.description)
   const entries = collectEntries(commands, [], groups)
+  // Pre-load yaml for `Skill.split`'s sync call path.
+  await Yaml.load()
   const files = Skill.split(cli.name, entries, depth, groups)
 
   if (depth > 0) await fs.rm(output, { recursive: true, force: true })

--- a/src/SyncSkills.ts
+++ b/src/SyncSkills.ts
@@ -2,10 +2,10 @@ import fsSync from 'node:fs'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { parse as yamlParse } from 'yaml'
 
 import { formatExamples } from './Cli.js'
 import * as Agents from './internal/agents.js'
+import * as Yaml from './internal/yaml.js'
 import * as Skill from './Skill.js'
 
 /** Generates skill files from a command map and installs them natively. */
@@ -16,6 +16,9 @@ export async function sync(
 ): Promise<sync.Result> {
   const { depth = 1, description, global = true } = options
   const cwd = options.cwd ?? (global ? resolvePackageRoot() : process.cwd())
+
+  // Pre-load yaml for the sync call paths below (`Skill.split`, `parseFrontmatter`).
+  await Yaml.load()
 
   const groups = new Map<string, string>()
   if (description) groups.set(name, description)
@@ -136,6 +139,9 @@ export async function list(
 ): Promise<list.Skill[]> {
   const { depth = 1, description } = options
   const cwd = options.cwd ?? process.cwd()
+
+  // Pre-load yaml for the sync call paths below (`Skill.split`, `parseFrontmatter`).
+  await Yaml.load()
 
   const groups = new Map<string, string>()
   if (description) groups.set(name, description)
@@ -287,7 +293,7 @@ function parseFrontmatter(content: string): {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
   if (!match) return {}
 
-  const meta = yamlParse(match[1]!)
+  const meta = Yaml.loadSync().parse(match[1]!)
   if (!meta || typeof meta !== 'object') return {}
   return meta as { description?: string | undefined; name?: string | undefined }
 }

--- a/src/bun-compile.test.ts
+++ b/src/bun-compile.test.ts
@@ -70,6 +70,11 @@ cli.serve()
     expect(stdout).toContain('result: HELLO')
   })
 
+  test('runs command with --format yaml (lazy yaml import)', async () => {
+    const { stdout } = await exec(bin, ['ping', '--format', 'yaml'])
+    expect(stdout).toContain('pong: true')
+  })
+
   test('shows help', async () => {
     const { stdout } = await exec(bin, ['--help'])
     expect(stdout).toContain('test-cli')

--- a/src/internal/yaml.ts
+++ b/src/internal/yaml.ts
@@ -1,0 +1,23 @@
+import { createRequire } from 'node:module'
+import type * as yaml from 'yaml'
+
+/** @internal Cached `yaml` module, shared by `load()` and `loadSync()`. */
+let cached: typeof yaml | undefined
+
+/** Loads the `yaml` module on demand, so runs that never touch YAML don't pay its startup cost. */
+export async function load(): Promise<typeof yaml> {
+  cached ??= await import('yaml')
+  return cached
+}
+
+/**
+ * Synchronous variant of `load()` for sync call paths (e.g. `Formatter.format`).
+ *
+ * Falls back to `require` when `load()` hasn't run yet. Async paths should call `load()`
+ * first so environments without synchronous module resolution (e.g. compiled binaries,
+ * bundled workers) never hit the fallback.
+ */
+export function loadSync(): typeof yaml {
+  cached ??= createRequire(import.meta.url)('yaml') as typeof yaml
+  return cached
+}

--- a/src/lazy-imports.test.ts
+++ b/src/lazy-imports.test.ts
@@ -1,0 +1,93 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+function exec(cmd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      cmd,
+      args,
+      { cwd: join(import.meta.dirname, '..'), timeout: 30_000 },
+      (error, stdout, stderr) => {
+        if (error) reject(new Error(stderr?.trim() || stdout?.trim() || error.message))
+        else resolve({ stdout, stderr })
+      },
+    )
+  })
+}
+
+let dir: string
+let src: string
+
+describe('lazy imports', () => {
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'incur-lazy-'))
+    src = join(dir, 'cli.mts')
+
+    // Records every module loaded during a CLI run, then prints the heavy ones.
+    await writeFile(
+      src,
+      `
+import { registerHooks } from 'node:module'
+
+const loaded: string[] = []
+registerHooks({
+  load(url, context, next) {
+    loaded.push(url)
+    return next(url, context)
+  },
+})
+
+const { Cli, z } = await import('${join(import.meta.dirname, 'index.ts')}')
+
+const cli = Cli.create('lazy-cli', { version: '1.0.0' })
+
+cli.command('ping', {
+  description: 'Health check',
+  options: z.object({ upper: z.boolean().default(false) }),
+  run() {
+    return { pong: true }
+  },
+})
+
+await cli.serve(process.argv.slice(2))
+
+const heavy = loaded.filter(
+  (url) => url.includes('@modelcontextprotocol') || url.includes('node_modules/yaml'),
+)
+console.log(JSON.stringify({ heavy }))
+`,
+    )
+  })
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  function parseHeavy(stdout: string): string[] {
+    const line = stdout.trim().split('\n').at(-1)!
+    return (JSON.parse(line) as { heavy: string[] }).heavy
+  }
+
+  test('plain command run does not load yaml or the MCP SDK', async () => {
+    const { stdout } = await exec(process.execPath, ['--import', 'tsx', src, 'ping'])
+    expect(stdout).toContain('pong: true')
+    expect(parseHeavy(stdout)).toEqual([])
+  })
+
+  test('--format yaml loads yaml on demand, but not the MCP SDK', async () => {
+    const { stdout } = await exec(process.execPath, [
+      '--import',
+      'tsx',
+      src,
+      'ping',
+      '--format',
+      'yaml',
+    ])
+    expect(stdout).toContain('pong: true')
+    const heavy = parseHeavy(stdout)
+    expect(heavy.some((url) => url.includes('node_modules/yaml'))).toBe(true)
+    expect(heavy.some((url) => url.includes('@modelcontextprotocol'))).toBe(false)
+  })
+})


### PR DESCRIPTION
incur-based CLIs currently pay for every feature on every invocation: `Cli.js` statically imports `yaml` (~72 modules at runtime) and `Mcp.js` statically imports `@modelcontextprotocol/server` (which pulls `@cfworker/json-schema`, ~15 modules and ~350KB of parse) — all loaded for a plain command run that uses none of them. Measured on a large production CLI, incur's eager surface was ~35% of all startup modules. For agent-driven CLIs invoked process-per-command, that's the dominant avoidable startup cost.

This PR loads both on first use instead:

- `@modelcontextprotocol/server` is now imported inside `Mcp.serve()` (the HTTP handler already imported it lazily), so it only loads when serving MCP (`--mcp`, `/mcp` over HTTP).
- `yaml` moves behind a small cached loader (`internal/yaml.ts`): async paths `await Yaml.load()`, and sync call paths (`Formatter.format`, `Skill.split` frontmatter) read the cache, with a `require` fallback for direct sync consumers. Every framework path that can reach yaml (`--format yaml`, command/CLI `format` defaults, skills sync/list/gen, `/openapi.yml`, `/.well-known/skills/*`) pre-warms the cache, so compiled binaries and bundled workers never depend on the fallback — `bun build --compile` only supports the `await import` form (verified; there's a new bun-compile test for `--format yaml`).
- `Openapi` is left eager deliberately: it has no heavy runtime deps and `index.ts` re-exports it, so a lazy import in `Cli.ts` wouldn't change what consumers load.

No public API changes: `Cli.create()`/`serve()`/`fetch()`, the `Mcp` namespace export, and sync `Formatter.format`/`Skill.split` all behave as before.

Minimal CLI (one command, `serve()`): **201 → 111 modules (−45%), ~77ms → ~46ms median process time (−40%)**. New `lazy-imports.test.ts` locks this in: a plain run loads zero `yaml`/MCP-SDK modules; `--format yaml` loads yaml on demand.

## Real-world data

The motivating case is [Murph](https://github.com/cobuildwithus/murph)'s `vault-cli` (~100 commands, scoped lazy command loading): a scoped read resolves ~300 modules total, of which incur's eager surface (yaml 72, MCP SDK + @cfworker/json-schema ~15, plus the always-loaded formatter/manifest internals) is **~110 modules — about 35%**. That CLI is invoked process-per-command by an LLM agent several times per turn, and in its 1-vCPU container a single scoped command costs ~780ms wall today — so the eager surface is worth on the order of a quarter second per command there, multiplied across every command of every agent turn. This patch is the difference between incur being a rounding error on that hot path versus its single largest line item.