### PR TITLE
fix: serialize bigint JSON output

### DIFF
--- a/.changeset/fix-bigint-json-output.md
+++ b/.changeset/fix-bigint-json-output.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Fixed BigInt serialization across JSON, JSONL, MCP, and fetch output paths.

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -3072,12 +3072,14 @@ describe('outputPolicy', () => {
       async *run() {
         yield { step: 1 }
         yield { step: 2 }
+        yield { expiry: 2461152330n }
       },
     })
 
     const { output } = await serve(cli, ['stream'])
     expect(output).toContain('{"type":"chunk","data":{"step":1}}')
     expect(output).toContain('{"type":"chunk","data":{"step":2}}')
+    expect(output).toContain('{"type":"chunk","data":{"expiry":"2461152330"}}')
   })
 
   test('e2e: realistic multi-level CLI with mixed policies', async () => {
@@ -4201,6 +4203,16 @@ describe('fetch', () => {
     `)
   })
 
+  test('serializes bigint values in command responses', async () => {
+    const cli = Cli.create('test')
+    cli.command('whois', {
+      output: z.object({ expiry: z.bigint() }),
+      run: () => ({ expiry: 2461152330n }),
+    })
+    const { body } = await fetchJson(cli, new Request('http://localhost/whois'))
+    expect(body.data).toEqual({ expiry: '2461152330' })
+  })
+
   test('trailing path segments → positional args', async () => {
     const cli = Cli.create('test')
     cli.command('users', {
@@ -4288,7 +4300,7 @@ describe('fetch', () => {
     cli.command('stream', {
       async *run() {
         yield { progress: 1 }
-        yield { progress: 2 }
+        yield { expiry: 2461152330n }
         return { done: true }
       },
     })
@@ -4310,7 +4322,7 @@ describe('fetch', () => {
         },
         {
           "data": {
-            "progress": 2,
+            "expiry": "2461152330",
           },
           "type": "chunk",
         },

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -22,6 +22,7 @@ import {
 } from './internal/command.js'
 import * as Command from './internal/command.js'
 import { isRecord, suggest, toKebab } from './internal/helpers.js'
+import * as Json from './internal/json.js'
 import { detectRunner } from './internal/pm.js'
 import type { OneOf } from './internal/types.js'
 import * as Mcp from './Mcp.js'
@@ -1595,7 +1596,7 @@ function createMcpHttpHandler(name: string, version: string) {
     },
   ): Promise<Response> => {
     if (!transport) {
-      const { McpServer, WebStandardStreamableHTTPServerTransport } =
+      const { fromJsonSchema, McpServer, WebStandardStreamableHTTPServerTransport } =
         await import('@modelcontextprotocol/server')
 
       const server = new McpServer({ name, version })
@@ -1612,6 +1613,9 @@ function createMcpHttpHandler(name: string, version: string) {
           {
             ...(tool.description ? { description: tool.description } : undefined),
             ...(hasInput ? { inputSchema: z.object(mergedShape) } : undefined),
+            ...(tool.outputSchema
+              ? { outputSchema: fromJsonSchema(tool.outputSchema) }
+              : undefined),
           },
           async (...callArgs: any[]) => {
             const params = hasInput ? (callArgs[0] as Record<string, unknown>) : {}
@@ -1750,7 +1754,7 @@ async function fetchImpl(
   }
 
   function jsonResponse(body: unknown, status: number) {
-    return new Response(JSON.stringify(body), {
+    return new Response(Json.stringify(body), {
       status,
       headers: { 'content-type': 'application/json' },
     })
@@ -1823,7 +1827,7 @@ async function executeCommand(
   options: fetchImpl.Options,
 ): Promise<Response> {
   function jsonResponse(body: unknown, status: number) {
-    return new Response(JSON.stringify(body), {
+    return new Response(Json.stringify(body), {
       status,
       headers: { 'content-type': 'application/json' },
     })
@@ -1860,12 +1864,12 @@ async function executeCommand(
         try {
           for await (const value of result.stream) {
             controller.enqueue(
-              encoder.encode(JSON.stringify({ type: 'chunk', data: value }) + '\n'),
+              encoder.encode(Json.stringify({ type: 'chunk', data: value }) + '\n'),
             )
           }
           controller.enqueue(
             encoder.encode(
-              JSON.stringify({
+              Json.stringify({
                 type: 'done',
                 ok: true,
                 meta: { command: path },
@@ -1875,7 +1879,7 @@ async function executeCommand(
         } catch (error) {
           controller.enqueue(
             encoder.encode(
-              JSON.stringify({
+              Json.stringify({
                 type: 'error',
                 ok: false,
                 error: {
@@ -2667,7 +2671,7 @@ async function handleStreaming(
             return
           }
         }
-        if (useJsonl) ctx.writeln(JSON.stringify({ type: 'chunk', data: value }))
+        if (useJsonl) ctx.writeln(Json.stringify({ type: 'chunk', data: value }))
         else if (ctx.renderOutput)
           ctx.writeln(ctx.truncate(Formatter.format(value, ctx.format)).text)
       }

--- a/src/Formatter.test.ts
+++ b/src/Formatter.test.ts
@@ -62,6 +62,15 @@ describe('format', () => {
     `)
   })
 
+  test('formats bigint values as strings in JSON', () => {
+    const result = Formatter.format({ expiry: 2461152330n }, 'json')
+    expect(result).toMatchInlineSnapshot(`
+      "{
+        "expiry": "2461152330"
+      }"
+    `)
+  })
+
   test('formats as YAML', () => {
     const result = Formatter.format({ message: 'hello' }, 'yaml')
     expect(result).toMatchInlineSnapshot(`
@@ -316,6 +325,14 @@ describe('format jsonl', () => {
     expect(result).toMatchInlineSnapshot(`
       "{"id":1}
       {"id":2}"
+    `)
+  })
+
+  test('array outputs bigint values as strings', () => {
+    const result = Formatter.format([{ expiry: 2461152330n }, { expiry: 2461152331n }], 'jsonl')
+    expect(result).toMatchInlineSnapshot(`
+      "{"expiry":"2461152330"}
+      {"expiry":"2461152331"}"
     `)
   })
 

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -1,6 +1,8 @@
 import { encode } from '@toon-format/toon'
 import { stringify as yamlStringify } from 'yaml'
 
+import * as Json from './internal/json.js'
+
 /** Supported output formats. */
 export type Format = 'toon' | 'json' | 'yaml' | 'md' | 'jsonl'
 
@@ -16,13 +18,13 @@ export function format(value: unknown, fmt: Format = 'toon'): string {
         } catch {}
       }
     }
-    return JSON.stringify(value, null, 2)
+    return Json.stringify(value, 2)
   }
   if (fmt === 'yaml') return yamlStringify(value)
   if (fmt === 'md') return formatMarkdown(value)
   if (fmt === 'jsonl') {
-    if (Array.isArray(value)) return value.map((v) => JSON.stringify(v)).join('\n')
-    return JSON.stringify(value)
+    if (Array.isArray(value)) return value.map((v) => Json.stringify(v)).join('\n')
+    return Json.stringify(value)
   }
   // toon (default)
   if (isScalar(value)) return String(value)

--- a/src/Mcp.test.ts
+++ b/src/Mcp.test.ts
@@ -181,6 +181,7 @@ describe('Mcp', () => {
     const commands = new Map<string, any>()
     commands.set('whois', {
       description: 'Return ENS data',
+      output: z.object({ expiry: z.bigint() }),
       run() {
         return { expiry: 2461152330n }
       },
@@ -192,6 +193,7 @@ describe('Mcp', () => {
     ])
     expect(res.result.isError).toBeUndefined()
     expect(res.result.content).toEqual([{ type: 'text', text: '{"expiry":"2461152330"}' }])
+    expect(res.result.structuredContent).toEqual({ expiry: '2461152330' })
   })
 
   test('callTool serializes bigint values as strings', async () => {
@@ -199,6 +201,11 @@ describe('Mcp', () => {
       {
         name: 'whois',
         inputSchema: { type: 'object', properties: {} },
+        outputSchema: {
+          type: 'object',
+          properties: { expiry: { type: 'string' } },
+          required: ['expiry'],
+        },
         command: {
           run() {
             return { expiry: 2461152330n }
@@ -210,6 +217,7 @@ describe('Mcp', () => {
 
     expect(result.isError).toBeUndefined()
     expect(result.content).toEqual([{ type: 'text', text: '{"expiry":"2461152330"}' }])
+    expect(result.structuredContent).toEqual({ expiry: '2461152330' })
   })
 
   test('callTool serializes streamed bigint chunks as strings', async () => {

--- a/src/Mcp.test.ts
+++ b/src/Mcp.test.ts
@@ -177,6 +177,67 @@ describe('Mcp', () => {
     expect(res.result.content).toEqual([{ type: 'text', text: '{"greeting":"hello world"}' }])
   })
 
+  test('tools/call serializes bigint values as strings', async () => {
+    const commands = new Map<string, any>()
+    commands.set('whois', {
+      description: 'Return ENS data',
+      run() {
+        return { expiry: 2461152330n }
+      },
+    })
+
+    const [, res] = await mcpSession(commands, [
+      { id: 1, method: 'initialize', params: initParams },
+      { id: 2, method: 'tools/call', params: { name: 'whois', arguments: {} } },
+    ])
+    expect(res.result.isError).toBeUndefined()
+    expect(res.result.content).toEqual([{ type: 'text', text: '{"expiry":"2461152330"}' }])
+  })
+
+  test('callTool serializes bigint values as strings', async () => {
+    const result = await Mcp.callTool(
+      {
+        name: 'whois',
+        inputSchema: { type: 'object', properties: {} },
+        command: {
+          run() {
+            return { expiry: 2461152330n }
+          },
+        },
+      },
+      {},
+    )
+
+    expect(result.isError).toBeUndefined()
+    expect(result.content).toEqual([{ type: 'text', text: '{"expiry":"2461152330"}' }])
+  })
+
+  test('callTool serializes streamed bigint chunks as strings', async () => {
+    const notifications: any[] = []
+    const result = await Mcp.callTool(
+      {
+        name: 'whois',
+        inputSchema: { type: 'object', properties: {} },
+        command: {
+          async *run() {
+            yield { expiry: 2461152330n }
+          },
+        },
+      },
+      {},
+      {
+        extra: { mcpReq: { _meta: { progressToken: 'tok-1' } } },
+        sendNotification: async (notification) => {
+          notifications.push(notification)
+        },
+      },
+    )
+
+    expect(result.isError).toBeUndefined()
+    expect(result.content).toEqual([{ type: 'text', text: '[{"expiry":"2461152330"}]' }])
+    expect(notifications[0].params.message).toBe('{"expiry":"2461152330"}')
+  })
+
   test('tools/call unknown tool returns error', async () => {
     const [, res] = await mcpSession(createTestCommands(), [
       { id: 1, method: 'initialize', params: initParams },

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -3,6 +3,7 @@ import type { Readable, Writable } from 'node:stream'
 import { z } from 'zod'
 
 import * as Command from './internal/command.js'
+import * as Json from './internal/json.js'
 import type { Handler as MiddlewareHandler } from './middleware.js'
 import * as Schema from './Schema.js'
 
@@ -122,7 +123,7 @@ export async function callTool(
         if (progressToken !== undefined && options.sendNotification)
           await options.sendNotification({
             method: 'notifications/progress' as const,
-            params: { progressToken, progress: ++i, message: JSON.stringify(chunk) },
+            params: { progressToken, progress: ++i, message: Json.stringify(chunk) },
           })
       }
     } catch (err) {
@@ -131,7 +132,7 @@ export async function callTool(
         isError: true,
       }
     }
-    return { content: [{ type: 'text', text: JSON.stringify(chunks) }] }
+    return { content: [{ type: 'text', text: Json.stringify(chunks) }] }
   }
 
   if (!result.ok)
@@ -142,7 +143,7 @@ export async function callTool(
 
   const data = result.data ?? null
   return {
-    content: [{ type: 'text', text: JSON.stringify(data) }],
+    content: [{ type: 'text', text: Json.stringify(data) }],
     ...(data !== null && tool.outputSchema
       ? { structuredContent: data as Record<string, unknown> }
       : undefined),

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -1,4 +1,4 @@
-import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server'
+import { fromJsonSchema, McpServer, StdioServerTransport } from '@modelcontextprotocol/server'
 import type { Readable, Writable } from 'node:stream'
 import { z } from 'zod'
 
@@ -28,7 +28,7 @@ export async function serve(
       {
         ...(tool.description ? { description: tool.description } : undefined),
         ...(hasInput ? { inputSchema: z.object(mergedShape) } : undefined),
-        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : undefined),
+        ...(tool.outputSchema ? { outputSchema: fromJsonSchema(tool.outputSchema) } : undefined),
       } as never,
       async (...callArgs: any[]) => {
         // registerTool passes (args, extra) when inputSchema is set, (extra) when not
@@ -142,10 +142,11 @@ export async function callTool(
     }
 
   const data = result.data ?? null
+  const jsonData = Json.normalize(data)
   return {
-    content: [{ type: 'text', text: Json.stringify(data) }],
+    content: [{ type: 'text', text: Json.stringify(jsonData) }],
     ...(data !== null && tool.outputSchema
-      ? { structuredContent: data as Record<string, unknown> }
+      ? { structuredContent: jsonData as Record<string, unknown> }
       : undefined),
   }
 }

--- a/src/internal/json.ts
+++ b/src/internal/json.ts
@@ -1,0 +1,11 @@
+/** Serializes JSON with BigInt values represented as decimal strings. */
+export function stringify(value: unknown, space?: number): string {
+  return JSON.stringify(
+    value,
+    (_key, value) => {
+      if (typeof value === 'bigint') return value.toString()
+      return value
+    },
+    space,
+  )
+}

--- a/src/internal/json.ts
+++ b/src/internal/json.ts
@@ -9,3 +9,8 @@ export function stringify(value: unknown, space?: number): string {
     space,
   )
 }
+
+/** Converts a value to JSON-compatible data. */
+export function normalize(value: unknown): unknown {
+  return JSON.parse(stringify(value))
+}


### PR DESCRIPTION
## Summary

- serialize `bigint` values as decimal strings when formatting JSON and JSONL output
- use the same JSON stringifier for MCP `tools/call` text output and streamed progress messages
- add regressions for formatter output, direct MCP calls, session `tools/call`, and streamed chunks

## Changes

- Added a small shared JSON stringifier that converts `bigint` values to decimal strings.
- Swapped JSON and JSONL formatter paths to use that helper.
- Swapped MCP `callTool` result serialization and streamed progress serialization to use the same helper.
- Covered the CLI formatter and MCP paths with focused regressions.

## Why

Commands can legitimately return `bigint` values, especially web3-style commands that expose block heights, expiries, balances, or token amounts. The default TOON formatter already handles those values, but JSON output and MCP tool calls currently rely on bare `JSON.stringify`, which throws before a caller can receive a valid result.

This makes JSON-style output paths match the existing TOON behavior by representing `bigint` values as decimal strings.

## Verification

```sh
pnpm exec vitest run src/Formatter.test.ts src/Mcp.test.ts
pnpm run check:types
pnpm run check
pnpm exec vitest run src/Formatter.test.ts src/Mcp.test.ts src/Cli.test.ts src/e2e.test.ts --bail=1
pnpm run test --bail=1 --coverage
```

Closes #161
