### PR TITLE
feat(skills): add destructive command hints

### DIFF
--- a/.changeset/destructive-skill-hints.md
+++ b/.changeset/destructive-skill-hints.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Added destructive command hints to generated skill files.

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -375,6 +375,18 @@ test('command mcp metadata accepts instructions and annotations', () => {
   })
 })
 
+test('command metadata accepts destructive flag', () => {
+  Cli.create('test').command('destroy', {
+    destructive: true,
+    run: () => ({ ok: true }),
+  })
+
+  Cli.create('destroy', {
+    destructive: true,
+    run: () => ({ ok: true }),
+  })
+})
+
 test('root run() context exposes displayName', () => {
   Cli.create('test', {
     run(c) {

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -3973,6 +3973,42 @@ test('--llms includes hint in skill output', async () => {
   expect(output).toContain('Always confirm before deploying to production')
 })
 
+test('--llms appends confirmation hint for destructive commands', async () => {
+  const cli = Cli.create('test')
+  cli.command('destroy', {
+    description: 'Destroy the app',
+    destructive: true,
+    hint: 'Deletes production resources.',
+    run: () => ({}),
+  })
+  cli.command('status', {
+    description: 'Show status',
+    hint: 'Read-only status check.',
+    run: () => ({}),
+  })
+
+  const { output } = await serve(cli, ['--llms-full'])
+  expect(output).toContain(
+    'Deletes production resources. Confirm with the user before executing this destructive command.',
+  )
+  expect(output).toContain('Read-only status check.')
+  expect(output).not.toContain(
+    'Read-only status check. Confirm with the user before executing this destructive command.',
+  )
+})
+
+test('--llms treats MCP destructiveHint as destructive', async () => {
+  const cli = Cli.create('test')
+  cli.command('deploy', {
+    description: 'Deploy the app',
+    mcp: { annotations: { destructiveHint: true } },
+    run: () => ({}),
+  })
+
+  const { output } = await serve(cli, ['--llms-full'])
+  expect(output).toContain('Confirm with the user before executing this destructive command.')
+})
+
 describe('fetch', async () => {
   const { app } = await import('../test/fixtures/hono-api.js')
 

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -36,6 +36,8 @@ import * as Skill from './Skill.js'
 import * as SyncMcp from './SyncMcp.js'
 import * as SyncSkills from './SyncSkills.js'
 
+const destructiveCommandHint = 'Confirm with the user before executing this destructive command.'
+
 /** A CLI application instance. Also used as a command group when mounted on a parent CLI. */
 export type Cli<
   commands extends CommandsMap = {},
@@ -472,6 +474,8 @@ export declare namespace create {
       | undefined
     /** A short description of what the CLI does. */
     description?: string | undefined
+    /** Marks the root command as destructive when generating agent skills. */
+    destructive?: boolean | undefined
     /** Zod schema for environment variables. Keys are the variable names (e.g. `NPM_TOKEN`). */
     env?: env | undefined
     /** Usage examples for this command. */
@@ -3256,6 +3260,7 @@ export function collectSkillCommands(
     if (rootCommand.args) cmd.args = rootCommand.args
     if (rootCommand.env) cmd.env = rootCommand.env
     if (rootCommand.hint) cmd.hint = rootCommand.hint
+    if (isDestructive(rootCommand)) cmd.hint = appendDestructiveHint(cmd.hint)
     if (rootCommand.options) cmd.options = rootCommand.options
     if (rootCommand.output) cmd.output = rootCommand.output
     const examples = formatExamples(rootCommand.examples)
@@ -3279,6 +3284,7 @@ export function collectSkillCommands(
       if (entry.args) cmd.args = entry.args
       if (entry.env) cmd.env = entry.env
       if (entry.hint) cmd.hint = entry.hint
+      if (isDestructive(entry)) cmd.hint = appendDestructiveHint(cmd.hint)
       if (entry.options) cmd.options = entry.options
       if (entry.output) cmd.output = entry.output
       const examples = formatExamples(entry.examples)
@@ -3297,8 +3303,26 @@ export function collectSkillCommands(
 
 type SkillCommandSource = Pick<
   CommandDefinition<any, any, any, any, any, any>,
-  'args' | 'description' | 'env' | 'examples' | 'hint' | 'options' | 'output'
+  | 'args'
+  | 'description'
+  | 'destructive'
+  | 'env'
+  | 'examples'
+  | 'hint'
+  | 'mcp'
+  | 'options'
+  | 'output'
 >
+
+function isDestructive(command: SkillCommandSource): boolean {
+  return command.destructive === true || command.mcp?.annotations?.destructiveHint === true
+}
+
+function appendDestructiveHint(hint: string | undefined): string {
+  if (!hint) return destructiveCommandHint
+  if (hint.includes(destructiveCommandHint)) return hint
+  return `${hint} ${destructiveCommandHint}`
+}
 
 /** @internal Formats examples into `{ command, description }` objects. `command` is the args/options suffix only. */
 export function formatExamples(
@@ -3456,6 +3480,8 @@ type CommandDefinition<
   args?: args | undefined
   /** Zod schema for environment variables. Keys are the variable names (e.g. `NPM_TOKEN`). */
   env?: env | undefined
+  /** Marks this command as destructive when generating agent skills. */
+  destructive?: boolean | undefined
   /** Usage examples for this command. */
   examples?: Example<args, options>[] | undefined
   /** Default output format. Overridden by `--format` or `--json`. */

--- a/src/Skill.test.ts
+++ b/src/Skill.test.ts
@@ -204,6 +204,12 @@ describe('hash', () => {
     expect(a).not.toBe(b)
   })
 
+  test('changes when hint changes', () => {
+    const a = Skill.hash([{ name: 'ping', hint: 'Read status.' }])
+    const b = Skill.hash([{ name: 'ping', hint: 'Delete status.' }])
+    expect(a).not.toBe(b)
+  })
+
   test('changes when schema changes', () => {
     const a = Skill.hash([{ name: 'greet', args: z.object({ name: z.string() }) }])
     const b = Skill.hash([{ name: 'greet', args: z.object({ name: z.string(), age: z.number() }) }])

--- a/src/Skill.ts
+++ b/src/Skill.ts
@@ -247,6 +247,7 @@ export function hash(commands: CommandInfo[]): string {
   const data = commands.map((cmd) => ({
     name: cmd.name,
     description: cmd.description,
+    hint: cmd.hint,
     args: cmd.args ? Schema.toJsonSchema(cmd.args) : undefined,
     env: cmd.env ? Schema.toJsonSchema(cmd.env) : undefined,
     options: cmd.options ? Schema.toJsonSchema(cmd.options) : undefined,

--- a/src/Skillgen.test.ts
+++ b/src/Skillgen.test.ts
@@ -85,3 +85,42 @@ test('includes args, options, and examples in output', async () => {
   expect(content).toContain('Fetch gateway. Pass path segments')
   expect(content).not.toContain('# tool hi')
 })
+
+test('appends confirmation hint for destructive commands', async () => {
+  const cli = Cli.create('tool')
+    .command('destroy', {
+      description: 'Destroy data',
+      destructive: true,
+      hint: 'Deletes all data.',
+      run: () => ({}),
+    })
+    .command('status', {
+      description: 'Check status',
+      hint: 'Shows current status.',
+      run: () => ({}),
+    })
+  vi.mocked(importCli).mockResolvedValue(cli)
+
+  const files = await generate('fake-input', tmp, 0)
+  const content = readFileSync(files[0]!, 'utf-8')
+  expect(content).toContain(
+    'Deletes all data. Confirm with the user before executing this destructive command.',
+  )
+  expect(content).toContain('Shows current status.')
+  expect(content).not.toContain(
+    'Shows current status. Confirm with the user before executing this destructive command.',
+  )
+})
+
+test('uses MCP destructiveHint when generating skill files', async () => {
+  const cli = Cli.create('tool').command('deploy', {
+    description: 'Deploy',
+    mcp: { annotations: { destructiveHint: true } },
+    run: () => ({}),
+  })
+  vi.mocked(importCli).mockResolvedValue(cli)
+
+  const files = await generate('fake-input', tmp, 0)
+  const content = readFileSync(files[0]!, 'utf-8')
+  expect(content).toContain('Confirm with the user before executing this destructive command.')
+})

--- a/src/SyncSkills.test.ts
+++ b/src/SyncSkills.test.ts
@@ -161,6 +161,45 @@ test('installed SKILL.md contains frontmatter', async () => {
   rmSync(tmp, { recursive: true, force: true })
 })
 
+test('installed SKILL.md marks destructive commands', async () => {
+  const tmp = join(tmpdir(), `clac-destructive-test-${Date.now()}`)
+  mkdirSync(tmp, { recursive: true })
+
+  const cli = Cli.create('my-tool')
+  cli.command('destroy', {
+    description: 'Destroy data',
+    destructive: true,
+    hint: 'Deletes all data.',
+    run: () => ({}),
+  })
+  cli.command('status', {
+    description: 'Check status',
+    hint: 'Shows current status.',
+    run: () => ({}),
+  })
+
+  const commands = Cli.toCommands.get(cli)!
+  const installDir = join(tmp, 'install')
+  mkdirSync(join(installDir, '.agents', 'skills'), { recursive: true })
+
+  const result = await SyncSkills.sync('my-tool', commands, {
+    depth: 0,
+    global: false,
+    cwd: installDir,
+  })
+
+  const content = readFileSync(join(result.paths[0]!, 'SKILL.md'), 'utf8')
+  expect(content).toContain(
+    'Deletes all data. Confirm with the user before executing this destructive command.',
+  )
+  expect(content).toContain('Shows current status.')
+  expect(content).not.toContain(
+    'Shows current status. Confirm with the user before executing this destructive command.',
+  )
+
+  rmSync(tmp, { recursive: true, force: true })
+})
+
 test('sync returns unquoted descriptions from YAML frontmatter', async () => {
   const tmp = join(tmpdir(), `clac-quoted-description-test-${Date.now()}`)
   mkdirSync(tmp, { recursive: true })

--- a/src/SyncSkills.ts
+++ b/src/SyncSkills.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { collectSkillCommands, parseSkillFrontmatter } from './Cli.js'
 import * as Agents from './internal/agents.js'
 import * as Yaml from './internal/yaml.js'
+import type * as Mcp from './Mcp.js'
 import * as Skill from './Skill.js'
 
 /** Generates skill files from a command map and installs them natively. */
@@ -103,8 +104,10 @@ export declare namespace sync {
       | {
           description?: string | undefined
           args?: any
+          destructive?: boolean | undefined
           env?: any
           hint?: string | undefined
+          mcp?: { annotations?: Mcp.ToolAnnotations | undefined } | undefined
           options?: any
           output?: any
           examples?: any[] | undefined
@@ -210,8 +213,10 @@ export declare namespace list {
       | {
           description?: string | undefined
           args?: any
+          destructive?: boolean | undefined
           env?: any
           hint?: string | undefined
+          mcp?: { annotations?: Mcp.ToolAnnotations | undefined } | undefined
           options?: any
           output?: any
           examples?: any[] | undefined


### PR DESCRIPTION
Adds a `destructive` command definition flag and bridges existing MCP `annotations.destructiveHint` metadata into generated skill bundles.

Generated `SKILL.md` command hints now include a confirmation reminder for destructive commands, while non-destructive commands keep their existing hints unchanged. Skill staleness hashing also accounts for hint text so synced skills are refreshed when this metadata changes.

Closes https://github.com/wevm/incur/issues/59
