### PR TITLE
fix: default `/mcp` http transport to stateless

### DIFF
--- a/.changeset/fix-mcp-http-workers.md
+++ b/.changeset/fix-mcp-http-workers.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Defaulted MCP-over-HTTP to stateless transport behavior and returned `405` for unsupported stateless methods.

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -369,6 +369,7 @@ test('command mcp metadata accepts instructions and annotations', () => {
   Cli.create('test', {
     mcp: {
       instructions: 'Use this server for test commands.',
+      stateless: false,
       // @ts-expect-error -- annotations belong on command definitions
       annotations: { readOnlyHint: true },
     },

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -5176,8 +5176,12 @@ describe('fetch', () => {
       const sessionId = res.headers.get('mcp-session-id')
       const body = await res.json()
       // Send initialized notification
-      await mcpRequest(cli, { jsonrpc: '2.0', method: 'notifications/initialized' }, sessionId!)
-      return { sessionId: sessionId!, body }
+      await mcpRequest(
+        cli,
+        { jsonrpc: '2.0', method: 'notifications/initialized' },
+        sessionId ?? undefined,
+      )
+      return { sessionId: sessionId ?? undefined, body }
     }
 
     test('POST /mcp with initialize → valid MCP response', async () => {
@@ -5193,6 +5197,7 @@ describe('fetch', () => {
         },
       })
       expect(res.status).toBe(200)
+      expect(res.headers.get('mcp-session-id')).toBeNull()
       const body = await res.json()
       expect({
         serverInfo: body.result.serverInfo,
@@ -5205,6 +5210,34 @@ describe('fetch', () => {
             "version": "1.0.0",
           },
         }
+      `)
+    })
+
+    test('POST /mcp with tools/list works without session state', async () => {
+      const cli = mcpCli()
+      await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      })
+      const res = await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.result.tools.map((t: any) => t.name)).toMatchInlineSnapshot(`
+        [
+          "greet",
+          "ping",
+        ]
       `)
     })
 
@@ -5237,6 +5270,37 @@ describe('fetch', () => {
           },
         ]
       `)
+    })
+
+    test('GET /mcp returns method not allowed in stateless mode', async () => {
+      const cli = mcpCli()
+      const res = await cli.fetch(
+        new Request('http://localhost/mcp', {
+          method: 'GET',
+          headers: { accept: 'text/event-stream' },
+        }),
+      )
+      expect(res.status).toBe(405)
+      expect(res.headers.get('allow')).toBe('POST')
+      expect(await res.text()).toBe('')
+    })
+
+    test('mcp.stateless false keeps stateful session handling', async () => {
+      const cli = Cli.create('test', { version: '1.0.0', mcp: { stateless: false } })
+      cli.command('ping', {
+        description: 'Ping',
+        run: () => ({ pong: true }),
+      })
+      const { sessionId } = await initSession(cli)
+      expect(sessionId).toEqual(expect.any(String))
+
+      const res = await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      })
+      expect(res.status).toBe(400)
     })
 
     test('POST /mcp with tools/call → executes command', async () => {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -241,7 +241,9 @@ export function create(
   const commands = new Map<string, CommandEntry>()
   const middlewares: MiddlewareHandler[] = []
   const pending: Promise<void>[] = []
-  const mcpHandler = createMcpHttpHandler(name, def.version ?? '0.0.0')
+  const mcpHandler = createMcpHttpHandler(name, def.version ?? '0.0.0', {
+    stateless: def.mcp?.stateless,
+  })
 
   if (def.openapi && rootFetch) {
     pending.push(
@@ -542,7 +544,7 @@ export declare namespace create {
           | Promise<InferReturn<output>>
           | AsyncGenerator<InferReturn<output>, unknown, unknown>)
       | undefined
-    /** Options for the built-in `mcp add` command. */
+    /** Options for MCP integration. */
     mcp?:
       | {
           /** Target specific agents by default (e.g. `['claude-code', 'cursor']`). */
@@ -551,6 +553,8 @@ export declare namespace create {
           command?: string | undefined
           /** Instructions describing how to use the server and its features. */
           instructions?: string | undefined
+          /** Disable HTTP MCP session management. Defaults to `true`. */
+          stateless?: boolean | undefined
         }
       | undefined
     /** Options for the built-in `skills add` command. */
@@ -1761,7 +1765,11 @@ declare namespace fetchImpl {
 }
 
 /** @internal Creates a lazy MCP HTTP handler scoped to a CLI instance. */
-function createMcpHttpHandler(name: string, version: string) {
+function createMcpHttpHandler(
+  name: string,
+  version: string,
+  options: createMcpHttpHandler.Options = {},
+) {
   let transport: any
 
   return async (
@@ -1773,6 +1781,10 @@ function createMcpHttpHandler(name: string, version: string) {
       vars?: z.ZodObject<any> | undefined
     },
   ): Promise<Response> => {
+    const stateless = options.stateless ?? true
+    if (stateless && req.method !== 'POST')
+      return new Response(null, { status: 405, headers: { Allow: 'POST' } })
+
     if (!transport) {
       const { fromJsonSchema, McpServer, WebStandardStreamableHTTPServerTransport } =
         await import('@modelcontextprotocol/server')
@@ -1808,13 +1820,23 @@ function createMcpHttpHandler(name: string, version: string) {
         )
       }
 
-      transport = new WebStandardStreamableHTTPServerTransport({
-        sessionIdGenerator: () => crypto.randomUUID(),
-        enableJsonResponse: true,
-      })
+      const transportOptions = stateless
+        ? { enableJsonResponse: true }
+        : {
+            sessionIdGenerator: () => crypto.randomUUID(),
+            enableJsonResponse: true,
+          }
+      transport = new WebStandardStreamableHTTPServerTransport(transportOptions)
       await server.connect(transport)
     }
     return transport.handleRequest(req)
+  }
+}
+
+declare namespace createMcpHttpHandler {
+  type Options = {
+    /** Disable HTTP MCP session management. Defaults to `true`. */
+    stateless?: boolean | undefined
   }
 }
 
@@ -2369,6 +2391,7 @@ declare namespace serveImpl {
           agents?: string[] | undefined
           command?: string | undefined
           instructions?: string | undefined
+          stateless?: boolean | undefined
         }
       | undefined
     /** Banner config, called before root help. */

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -2950,7 +2950,7 @@ describe('fetch api', () => {
           clientInfo: { name: 'test-client', version: '1.0.0' },
         },
       })
-      const sessionId = res.headers.get('mcp-session-id')!
+      const sessionId = res.headers.get('mcp-session-id') ?? undefined
       await mcpRequest(cli, { jsonrpc: '2.0', method: 'notifications/initialized' }, sessionId)
       return sessionId
     }
@@ -2968,6 +2968,7 @@ describe('fetch api', () => {
         },
       })
       expect(res.status).toBe(200)
+      expect(res.headers.get('mcp-session-id')).toBeNull()
       const body = await res.json()
       expect({
         serverInfo: body.result.serverInfo,
@@ -2981,6 +2982,41 @@ describe('fetch api', () => {
           },
         }
       `)
+    })
+
+    test('tools/list works without session state', async () => {
+      const cli = createApp()
+      await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      })
+      const res = await mcpRequest(cli, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.result.tools.map((t: any) => t.name).sort()).toContain('ping')
+    })
+
+    test('GET /mcp returns method not allowed in stateless mode', async () => {
+      const cli = createApp()
+      const res = await cli.fetch(
+        new Request('http://localhost/mcp', {
+          method: 'GET',
+          headers: { accept: 'text/event-stream' },
+        }),
+      )
+      expect(res.status).toBe(405)
+      expect(res.headers.get('allow')).toBe('POST')
     })
 
     test('tools/list → lists all registered tools', async () => {


### PR DESCRIPTION
Defaults MCP-over-HTTP to stateless transport behavior so `/mcp` works across Cloudflare Workers isolates without relying on in-memory session state.

Unsupported stateless methods now return `405` with `Allow: POST`, which keeps Streamable HTTP clients from opening a hanging SSE listen stream when the server does not support it.

Fixes https://github.com/wevm/incur/issues/162
