### PR TITLE
fix: type `Cli.create` root command `hint`

### DIFF
--- a/.changeset/type-root-command-hint.md
+++ b/.changeset/type-root-command-hint.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Typed the root command `hint` option on `Cli.create`.

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -384,6 +384,19 @@ test('root run() context exposes displayName', () => {
   })
 })
 
+test('create() accepts root command hint', () => {
+  Cli.create('test', {
+    hint: 'Fetch immediately before sending the transaction.',
+    run: () => ({ ok: true }),
+  })
+
+  Cli.create({
+    name: 'test',
+    hint: 'Fetch immediately before sending the transaction.',
+    run: () => ({ ok: true }),
+  })
+})
+
 test('create() accepts config-file defaults options', () => {
   Cli.create('test', {
     config: {},

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -484,6 +484,8 @@ export declare namespace create {
     openapiConfig?: Openapi.Config | undefined
     /** Default output format. Overridden by `--format` or `--json`. */
     format?: Formatter.Format | undefined
+    /** Plain text hint displayed after examples and before global options. */
+    hint?: string | undefined
     /** Map of global option names to single-char aliases. */
     globalAlias?: globals extends z.ZodObject<any>
       ? Partial<Record<keyof z.output<globals>, string>>


### PR DESCRIPTION
Adds `hint?: string | undefined` to `Cli.create` options so root/leaf CLIs can use the runtime-supported hint metadata without excess property errors.

This matches existing `CommandDefinition` behavior and fixes https://github.com/wevm/incur/issues/163. Focused type coverage now checks both string-name and object-name `Cli.create` forms.
