### PR TITLE
feat(mcp): surface tool response `cta`

### DIFF
--- a/.changeset/surface-mcp-cta.md
+++ b/.changeset/surface-mcp-cta.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Surfaced `c.ok(..., { cta })` metadata on MCP tool responses under `_meta.cta`.

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -20,6 +20,7 @@ import {
   shells,
 } from './internal/command.js'
 import * as Command from './internal/command.js'
+import { formatCtaBlock, type FormattedCta, type FormattedCtaBlock } from './internal/cta.js'
 import { isRecord, suggest, toKebab } from './internal/helpers.js'
 import * as Json from './internal/json.js'
 import { detectRunner } from './internal/pm.js'
@@ -3121,31 +3122,6 @@ async function handleStreaming(
   }
 }
 
-/** @internal Formats a CTA block into the output envelope shape. */
-function formatCtaBlock(name: string, block: CtaBlock | undefined): FormattedCtaBlock | undefined {
-  if (!block || block.commands.length === 0) return undefined
-  return {
-    description:
-      block.description ??
-      (block.commands.length === 1 ? 'Suggested command:' : 'Suggested commands:'),
-    commands: block.commands.map((c) => formatCta(name, c)),
-  }
-}
-
-/** @internal Formats a CTA by prefixing the CLI name. Handles string and object forms. */
-function formatCta(name: string, cta: Cta): FormattedCta {
-  if (typeof cta === 'string') return { command: `${name} ${cta}` }
-  const prefix = cta.command === name || cta.command.startsWith(`${name} `) ? '' : `${name} `
-  let cmd = `${prefix}${cta.command}`
-  if (cta.args)
-    for (const [key, value] of Object.entries(cta.args))
-      cmd += value === true ? ` <${key}>` : ` ${value}`
-  if (cta.options)
-    for (const [key, value] of Object.entries(cta.options))
-      cmd += value === true ? ` --${key} <${key}>` : ` --${key} ${value}`
-  return { command: cmd, ...(cta.description ? { description: cta.description } : undefined) }
-}
-
 /** @internal Builds the `--llms` index manifest (name + description only) from the command tree. */
 function buildIndexManifest(
   commands: Map<string, CommandEntry>,
@@ -3521,22 +3497,6 @@ type CommandDefinition<
     | InferReturn<output>
     | Promise<InferReturn<output>>
     | AsyncGenerator<InferReturn<output>, unknown, unknown>
-}
-
-/** @internal A formatted CTA block as it appears in the output envelope. */
-type FormattedCtaBlock = {
-  /** Formatted command suggestions. */
-  commands: FormattedCta[]
-  /** Human-readable label for the CTA block. */
-  description: string
-}
-
-/** @internal A formatted CTA as it appears in the output envelope. */
-type FormattedCta = {
-  /** The full command string with args and options folded in. */
-  command: string
-  /** A short description of what the command does. */
-  description?: string | undefined
 }
 
 /** @internal Scans argv for deprecated flags and writes warnings to stderr. */

--- a/src/Mcp.test.ts
+++ b/src/Mcp.test.ts
@@ -208,6 +208,37 @@ describe('Mcp', () => {
     expect(res.result.structuredContent).toEqual({ expiry: '2461152330' })
   })
 
+  test('tools/call surfaces cta metadata without changing structured content', async () => {
+    const commands = new Map<string, any>()
+    commands.set('show', {
+      description: 'Show a record',
+      output: z.object({ id: z.string() }),
+      run(c: any) {
+        return c.ok(
+          { id: 'foo' },
+          {
+            cta: {
+              description: 'Next:',
+              commands: [{ command: 'list', description: 'List all' }],
+            },
+          },
+        )
+      },
+    })
+
+    const [, res] = await mcpSession(commands, [
+      { id: 1, method: 'initialize', params: initParams },
+      { id: 2, method: 'tools/call', params: { name: 'show', arguments: {} } },
+    ])
+
+    expect(res.result.content).toEqual([{ type: 'text', text: '{"id":"foo"}' }])
+    expect(res.result.structuredContent).toEqual({ id: 'foo' })
+    expect(res.result._meta?.cta).toEqual({
+      description: 'Next:',
+      commands: [{ command: 'test-cli list', description: 'List all' }],
+    })
+  })
+
   test('callTool serializes bigint values as strings', async () => {
     const result = await Mcp.callTool(
       {

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -2,6 +2,7 @@ import type { Readable, Writable } from 'node:stream'
 import { z } from 'zod'
 
 import * as Command from './internal/command.js'
+import { formatCtaBlock, type FormattedCtaBlock } from './internal/cta.js'
 import * as Json from './internal/json.js'
 import type { Handler as MiddlewareHandler } from './middleware.js'
 import * as Schema from './Schema.js'
@@ -99,6 +100,7 @@ export async function callTool(
 ): Promise<{
   content: { type: 'text'; text: string }[]
   structuredContent?: Record<string, unknown>
+  _meta?: { cta: FormattedCtaBlock } | undefined
   isError?: boolean
 }> {
   const allMiddleware = [
@@ -160,11 +162,13 @@ export async function callTool(
 
   const data = result.data ?? null
   const jsonData = Json.normalize(data)
+  const cta = formatCtaBlock(options.name ?? tool.name, result.cta as Command.CtaBlock | undefined)
   return {
     content: [{ type: 'text', text: Json.stringify(jsonData) }],
     ...(data !== null && tool.outputSchema
       ? { structuredContent: jsonData as Record<string, unknown> }
       : undefined),
+    ...(cta ? { _meta: { cta } } : undefined),
   }
 }
 

--- a/src/internal/cta.ts
+++ b/src/internal/cta.ts
@@ -1,0 +1,58 @@
+/** @internal A CTA block before command names are expanded. */
+export type CtaBlock = {
+  commands: unknown[]
+  description?: string | undefined
+}
+
+/** @internal A formatted CTA block as it appears in output metadata. */
+export type FormattedCtaBlock = {
+  /** Formatted command suggestions. */
+  commands: FormattedCta[]
+  /** Human-readable label for the CTA block. */
+  description: string
+}
+
+/** @internal A formatted CTA as it appears in output metadata. */
+export type FormattedCta = {
+  /** The full command string with args and options folded in. */
+  command: string
+  /** A short description of what the command does. */
+  description?: string | undefined
+}
+
+type Cta =
+  | string
+  | {
+      args?: Record<string, unknown> | undefined
+      command: string
+      description?: string | undefined
+      options?: Record<string, unknown> | undefined
+    }
+
+/** @internal Formats a CTA block into the output metadata shape. */
+export function formatCtaBlock(
+  name: string,
+  block: CtaBlock | undefined,
+): FormattedCtaBlock | undefined {
+  if (!block || block.commands.length === 0) return undefined
+  return {
+    description:
+      block.description ??
+      (block.commands.length === 1 ? 'Suggested command:' : 'Suggested commands:'),
+    commands: block.commands.map((c) => formatCta(name, c as Cta)),
+  }
+}
+
+/** @internal Formats a CTA by prefixing the CLI name. */
+function formatCta(name: string, cta: Cta): FormattedCta {
+  if (typeof cta === 'string') return { command: `${name} ${cta}` }
+  const prefix = cta.command === name || cta.command.startsWith(`${name} `) ? '' : `${name} `
+  let cmd = `${prefix}${cta.command}`
+  if (cta.args)
+    for (const [key, value] of Object.entries(cta.args))
+      cmd += value === true ? ` <${key}>` : ` ${value}`
+  if (cta.options)
+    for (const [key, value] of Object.entries(cta.options))
+      cmd += value === true ? ` --${key} <${key}>` : ` --${key} ${value}`
+  return { command: cmd, ...(cta.description ? { description: cta.description } : undefined) }
+}


### PR DESCRIPTION
Surfaced CTA metadata from successful tool results on MCP responses under `_meta.cta`, matching the CLI behavior without adding display-only metadata to structured content.

Closes https://github.com/wevm/incur/issues/140.
