### PR TITLE
fix: tolerate non-object MCP output schemas

### DIFF
--- a/.changeset/schema-safe-mcp-output.md
+++ b/.changeset/schema-safe-mcp-output.md
@@ -2,4 +2,4 @@
 "incur": patch
 ---
 
-Tolerate non-object MCP output schemas by omitting them from tool registration while preserving JSON text output.
+Added support for non-object MCP output schemas by omitting them from tool registration while preserving JSON text output.

--- a/.changeset/schema-safe-mcp-output.md
+++ b/.changeset/schema-safe-mcp-output.md
@@ -1,0 +1,5 @@
+---
+"incur": patch
+---
+
+Tolerate non-object MCP output schemas by omitting them from tool registration while preserving JSON text output.

--- a/src/Mcp.test.ts
+++ b/src/Mcp.test.ts
@@ -256,6 +256,54 @@ describe('Mcp', () => {
     expect(res.result.structuredContent).toEqual({ expiry: '2461152330' })
   })
 
+  test('tools/list tolerates non-object output schemas', async () => {
+    const commands = new Map<string, any>()
+    commands.set('list', {
+      description: 'List records',
+      output: z.array(z.object({ id: z.string() })),
+      run() {
+        return [{ id: 'foo' }]
+      },
+    })
+    commands.set('count', {
+      description: 'Count records',
+      output: z.number(),
+      run() {
+        return 1
+      },
+    })
+    commands.set('show', {
+      description: 'Show record',
+      output: z.object({ id: z.string() }),
+      run() {
+        return { id: 'foo' }
+      },
+    })
+
+    const tools = Mcp.collectTools(commands, [])
+    expect(tools.find((tool) => tool.name === 'list')?.outputSchema).toBeUndefined()
+    expect(tools.find((tool) => tool.name === 'count')?.outputSchema).toBeUndefined()
+    expect(tools.find((tool) => tool.name === 'show')?.outputSchema?.type).toBe('object')
+
+    const [, listRes] = await mcpSession(commands, [
+      { id: 1, method: 'initialize', params: initParams },
+      { id: 2, method: 'tools/list', params: {} },
+    ])
+    expect(listRes.error).toBeUndefined()
+    expect(listRes.result.tools.map((tool: any) => tool.name).sort()).toEqual([
+      'count',
+      'list',
+      'show',
+    ])
+
+    const [, callRes] = await mcpSession(commands, [
+      { id: 1, method: 'initialize', params: initParams },
+      { id: 2, method: 'tools/call', params: { name: 'list', arguments: {} } },
+    ])
+    expect(callRes.result.content).toEqual([{ type: 'text', text: '[{"id":"foo"}]' }])
+    expect(callRes.result.structuredContent).toBeUndefined()
+  })
+
   test('tools/call surfaces cta metadata without changing structured content', async () => {
     const commands = new Map<string, any>()
     commands.set('show', {

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -221,13 +221,12 @@ export function collectTools(
       ]
       result.push(...collectTools(entry.commands, path, groupMw))
     } else {
+      const outputSchema = entry.output ? mcpOutputSchema(entry.output) : undefined
       result.push({
         name: entry.mcp?.name ?? path.join('_'),
         description: entry.mcp?.description ?? entry.description,
         inputSchema: buildToolSchema(entry.args, entry.options),
-        ...(entry.output
-          ? { outputSchema: Schema.toJsonSchema(entry.output) as Record<string, unknown> }
-          : undefined),
+        ...(outputSchema ? { outputSchema } : undefined),
         ...(entry.mcp?.annotations ? { annotations: entry.mcp.annotations } : undefined),
         ...(entry.mcp?.instructions ? { instructions: entry.mcp.instructions } : undefined),
         command: entry,
@@ -245,6 +244,12 @@ function assertUniqueToolNames(tools: ToolEntry[]) {
     if (seen.has(tool.name)) throw new Error(`Duplicate MCP tool name: ${tool.name}`)
     seen.add(tool.name)
   }
+}
+
+function mcpOutputSchema(output: any): Record<string, unknown> | undefined {
+  const schema = Schema.toJsonSchema(output) as Record<string, unknown>
+  if (schema.type === 'object') return schema
+  return undefined
 }
 
 /** @internal Builds a merged JSON Schema from args and options Zod schemas. */


### PR DESCRIPTION
## Summary

- Omit MCP output schemas for command outputs that are not JSON objects
- Preserve structured content for object-shaped command outputs
- Cover array, primitive, and object output handling in MCP tests

## Motivation

Some MCP SDKs reject tool output schemas that are arrays or primitives during tool listing. Incur should keep the MCP server usable for commands whose CLI output is valid but not object-shaped.

## Key design considerations

- Leave command response serialization unchanged
- Keep structuredContent behavior only when MCP has an object output schema