### PR TITLE
feat: add MCP tool name metadata

### DIFF
--- a/.changeset/mcp-tool-metadata.md
+++ b/.changeset/mcp-tool-metadata.md
@@ -2,4 +2,4 @@
 "incur": minor
 ---
 
-Add MCP tool name and description metadata overrides for commands, including duplicate exposed-name validation.
+Added MCP tool name and description metadata overrides for commands, including duplicate exposed-name validation.

--- a/.changeset/mcp-tool-metadata.md
+++ b/.changeset/mcp-tool-metadata.md
@@ -1,0 +1,5 @@
+---
+"incur": minor
+---
+
+Add MCP tool name and description metadata overrides for commands, including duplicate exposed-name validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,4 @@
 ## Git Conventions
 
 - **Conventional commits** — use `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:` prefixes. Scope is optional (e.g. `feat(parser): add array coercion`).
+- **Changesets for package changes** — user-facing fixes and features require a `.changeset/*.md` entry in the same PR. Use `patch` for fixes, `minor` for additive features, and `major` for breaking changes. Skip only for tests, docs, or internal-only changes that do not affect the published package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,4 +41,3 @@
 ## Git Conventions
 
 - **Conventional commits** — use `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:` prefixes. Scope is optional (e.g. `feat(parser): add array coercion`).
-- **Changesets for package changes** — user-facing fixes and features require a `.changeset/*.md` entry in the same PR. Use `patch` for fixes, `minor` for additive features, and `major` for breaking changes. Skip only for tests, docs, or internal-only changes that do not affect the published package.

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -354,6 +354,8 @@ test('run() context exposes format metadata', () => {
 test('command mcp metadata accepts instructions and annotations', () => {
   Cli.create('test').command('read', {
     mcp: {
+      name: 'read_data',
+      description: 'Read data through MCP',
       annotations: {
         title: 'Read data',
         readOnlyHint: true,

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -5888,6 +5888,8 @@ describe('--mcp', () => {
       const cli = Cli.create('test')
       cli.command('deploy', {
         mcp: {
+          name: 'deploy_service',
+          description: 'Deploy service through MCP',
           annotations: { destructiveHint: true, idempotentHint: false },
           instructions: 'Require confirmation before production deploys.',
         },
@@ -5897,7 +5899,8 @@ describe('--mcp', () => {
 
       const commands = spy.mock.calls[0]![2] as Map<string, any>
       const [tool] = Mcp.collectTools(commands, [])
-      expect(tool?.name).toBe('deploy')
+      expect(tool?.name).toBe('deploy_service')
+      expect(tool?.description).toBe('Deploy service through MCP')
       expect(tool?.annotations).toEqual({ destructiveHint: true, idempotentHint: false })
       expect(tool?.instructions).toBe('Require confirmation before production deploys.')
     } finally {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -3492,6 +3492,10 @@ type CommandDefinition<
   /** MCP-specific metadata exposed when this command is served as a tool. */
   mcp?:
     | {
+        /** Override the command name exposed to MCP clients. */
+        name?: string | undefined
+        /** Override the command description exposed to MCP clients. */
+        description?: string | undefined
         /** MCP tool annotations that describe tool behavior to clients. */
         annotations?: Mcp.ToolAnnotations | undefined
         /** Tool-specific instructions surfaced to MCP clients. */

--- a/src/Mcp.test.ts
+++ b/src/Mcp.test.ts
@@ -134,6 +134,54 @@ describe('Mcp', () => {
     expect(echoTool.inputSchema.required).toContain('message')
   })
 
+  test('tools/list uses command MCP name and description overrides', async () => {
+    const commands = new Map<string, any>()
+    commands.set('whoami', {
+      description: 'Show wallet identity',
+      mcp: {
+        name: 'get_balance',
+        description: 'Get wallet balance',
+      },
+      run() {
+        return { balance: '1.00' }
+      },
+    })
+
+    const [, listRes] = await mcpSession(commands, [
+      { id: 1, method: 'initialize', params: initParams },
+      { id: 2, method: 'tools/list', params: {} },
+    ])
+    const names = listRes.result.tools.map((tool: any) => tool.name)
+    expect(names).toEqual(['get_balance'])
+    expect(listRes.result.tools[0].description).toBe('Get wallet balance')
+
+    const [, callRes] = await mcpSession(commands, [
+      { id: 1, method: 'initialize', params: initParams },
+      { id: 2, method: 'tools/call', params: { name: 'get_balance', arguments: {} } },
+    ])
+    expect(callRes.result.content).toEqual([{ type: 'text', text: '{"balance":"1.00"}' }])
+  })
+
+  test('collectTools rejects duplicate MCP tool names', () => {
+    const commands = new Map<string, any>()
+    commands.set('whoami', {
+      mcp: { name: 'get_balance' },
+      run() {
+        return { balance: '1.00' }
+      },
+    })
+    commands.set('balance', {
+      mcp: { name: 'get_balance' },
+      run() {
+        return { balance: '1.00' }
+      },
+    })
+
+    expect(() => Mcp.collectTools(commands, [])).toThrowError(
+      'Duplicate MCP tool name: get_balance',
+    )
+  })
+
   test('notifications are ignored (no response)', async () => {
     const responses = await mcpSession(createTestCommands(), [
       { id: 1, method: 'initialize', params: initParams },

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -222,8 +222,8 @@ export function collectTools(
       result.push(...collectTools(entry.commands, path, groupMw))
     } else {
       result.push({
-        name: path.join('_'),
-        description: entry.description,
+        name: entry.mcp?.name ?? path.join('_'),
+        description: entry.mcp?.description ?? entry.description,
         inputSchema: buildToolSchema(entry.args, entry.options),
         ...(entry.output
           ? { outputSchema: Schema.toJsonSchema(entry.output) as Record<string, unknown> }
@@ -235,7 +235,16 @@ export function collectTools(
       })
     }
   }
+  assertUniqueToolNames(result)
   return result.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function assertUniqueToolNames(tools: ToolEntry[]) {
+  const seen = new Set<string>()
+  for (const tool of tools) {
+    if (seen.has(tool.name)) throw new Error(`Duplicate MCP tool name: ${tool.name}`)
+    seen.add(tool.name)
+  }
 }
 
 /** @internal Builds a merged JSON Schema from args and options Zod schemas. */


### PR DESCRIPTION
## Summary

- Add command-level MCP name and description overrides
- Use overrides when collecting MCP tools
- Reject duplicate MCP tool names with a clear error

## Motivation

Agent-facing tool names often need to be stable and task-oriented rather than tied to CLI command paths.

## Key design considerations

- Preserve existing CLI command names, aliases, and help text
- Keep existing MCP annotations and instructions behavior
- Fail clearly when two commands map to the same MCP tool name