### PR TITLE
fix: resolve `--mcp` stdio transport import

### DIFF
--- a/.changeset/stable-mcp-stdio.md
+++ b/.changeset/stable-mcp-stdio.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Fixed `--mcp` stdio transport loading against `@modelcontextprotocol/server` prereleases that export it from `./stdio`.

--- a/src/Mcp.test.ts
+++ b/src/Mcp.test.ts
@@ -84,12 +84,19 @@ async function mcpSession(
     input.write(`${JSON.stringify(rpc)}\n`)
   }
 
-  // Give time for async processing then close
-  await new Promise((r) => setTimeout(r, 20))
+  await waitForResponses(chunks, messages.filter((msg) => msg.id !== undefined).length)
   input.end()
   await done
 
   return chunks.map((c) => JSON.parse(c.trim()))
+}
+
+async function waitForResponses(chunks: string[], expected: number) {
+  const started = Date.now()
+  while (chunks.length < expected) {
+    if (Date.now() - started > 1_000) return
+    await new Promise((r) => setTimeout(r, 5))
+  }
 }
 
 describe('Mcp', () => {

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -1,3 +1,4 @@
+import type { Transport } from '@modelcontextprotocol/server'
 import type { Readable, Writable } from 'node:stream'
 import { z } from 'zod'
 
@@ -15,8 +16,10 @@ export async function serve(
   options: serve.Options = {},
 ): Promise<void> {
   // Lazy: only runs when actually serving MCP, so plain command runs don't pay for the SDK import.
-  const { fromJsonSchema, McpServer, StdioServerTransport } =
-    await import('@modelcontextprotocol/server')
+  const stdio = importStdioModule()
+  const mcp = await import('@modelcontextprotocol/server')
+  const { fromJsonSchema, McpServer } = mcp
+  const StdioServerTransport = await importStdioServerTransport(mcp, stdio)
 
   const server = new McpServer(
     { name, version },
@@ -61,6 +64,40 @@ export async function serve(
   const transport = new StdioServerTransport(input as any, output as any)
   await server.connect(transport)
 }
+
+type StdioServerTransport = new (
+  input?: Readable,
+  output?: Writable,
+  options?: { maxBufferSize?: number | undefined },
+) => Transport
+
+type StdioModule = {
+  StdioServerTransport: StdioServerTransport
+}
+
+type StdioImportResult =
+  | { module: unknown; error?: undefined }
+  | { module?: undefined; error: unknown }
+
+async function importStdioServerTransport(
+  mcp: unknown,
+  stdio: Promise<StdioImportResult>,
+): Promise<StdioServerTransport> {
+  const transport = (mcp as Partial<StdioModule>).StdioServerTransport
+  if (transport) return transport
+
+  const result = await stdio
+  if (result.error) throw result.error
+  return (result.module as StdioModule).StdioServerTransport
+}
+
+function importStdioModule(): Promise<StdioImportResult> {
+  return importModule('@modelcontextprotocol/server/stdio')
+    .then((module) => ({ module }))
+    .catch((error: unknown) => ({ error }))
+}
+
+const importModule = (specifier: string): Promise<unknown> => import(specifier)
 
 export declare namespace serve {
   /** Options for the MCP server. */


### PR DESCRIPTION
Loads the stdio transport from the SDK root when available and falls back to `@modelcontextprotocol/server/stdio` for prereleases that moved the export. This keeps MCP startup lazy while allowing installs that resolve `^2.0.0-alpha.2` to alpha.3 to start.

Fixes https://github.com/wevm/incur/issues/174
