### PR TITLE
fix: respect explicit output format in TTY

### DIFF
--- a/.changeset/fuzzy-pumas-speak.md
+++ b/.changeset/fuzzy-pumas-speak.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Respect explicit output formats when stdout is a TTY so `--format` and `--json` output remains machine-readable.

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -2088,6 +2088,37 @@ describe('leaf cli', () => {
     expect(JSON.parse(output)).toEqual({ pong: true })
   })
 
+  test('--format json remains parseable in TTY output with CTAs', async () => {
+    const previous = process.stdout.isTTY
+    ;(process.stdout as any).isTTY = true
+    try {
+      const cli = Cli.create('ping', {
+        run(c) {
+          return c.ok(
+            { pong: true },
+            {
+              cta: {
+                description: 'Suggested command:',
+                commands: ['next'],
+              },
+            },
+          )
+        },
+      })
+      const { output } = await serve(cli, ['--format', 'json'])
+
+      expect(JSON.parse(output)).toEqual({
+        pong: true,
+        cta: {
+          description: 'Suggested command:',
+          commands: [{ command: 'ping next' }],
+        },
+      })
+    } finally {
+      ;(process.stdout as any).isTTY = previous
+    }
+  })
+
   test('errors wrap in error envelope', async () => {
     const cli = Cli.create('fail', {
       run() {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -605,7 +605,8 @@ async function serveImpl(
 ) {
   const stdout = options.stdout ?? ((s: string) => process.stdout.write(s))
   const exit = options.exit ?? ((code: number) => process.exit(code))
-  const human = process.stdout.isTTY === true
+  const tty = process.stdout.isTTY === true
+  let human = tty
   const configEnabled = options.config !== undefined
   const configFlag = options.config?.flag
   const displayName = resolveDisplayName(name, options.aliases)
@@ -657,6 +658,7 @@ async function serveImpl(
     configDisabled,
     rest,
   } = builtinFlags
+  human = tty && !formatExplicit
 
   let globals: Record<string, unknown> = {}
   let filtered = rest


### PR DESCRIPTION
Respect explicit output format requests in TTY mode so machine-readable output stays parseable. Fixes https://github.com/wevm/incur/issues/178