### PR TITLE
feat: add mcp command sources

### DIFF
--- a/.changeset/remote-mcp-sources.md
+++ b/.changeset/remote-mcp-sources.md
@@ -1,0 +1,5 @@
+---
+'incur': minor
+---
+
+Added remote MCP servers as command sources via `cli.command(name, { mcp })`.

--- a/.changeset/remote-mcp-sources.md
+++ b/.changeset/remote-mcp-sources.md
@@ -1,5 +1,5 @@
 ---
-'incur': minor
+'incur': patch
 ---
 
 Added remote MCP servers as command sources via `cli.command(name, { mcp })`.

--- a/README.md
+++ b/README.md
@@ -358,6 +358,29 @@ $ my-cli api users get --limit 5
 
 When served with `cli.fetch`, the generated spec is available at `/openapi.json`, `/openapi.yml`, `/openapi.yaml`, and `/.well-known/openapi.json`. Methods are inferred from command names: read-like commands use `GET`, update-like commands use `PATCH`, delete-like commands use `DELETE`, and other commands use `POST`.
 
+#### MCP command sources
+
+Pass a remote MCP streamable-HTTP endpoint to generate a command group from its tools:
+
+```ts
+import { Cli } from 'incur'
+
+Cli.create('my-cli', { description: 'My CLI' })
+  .command('docs', { mcp: 'https://mcp.tempo.xyz/mcp' })
+  .serve()
+```
+
+```sh
+$ my-cli docs --help
+# Commands:
+#   search  Search docs
+
+$ my-cli docs search --query tempo
+# → results: ...
+```
+
+Each MCP tool becomes a plain incur subcommand, so it is also available through `cli.fetch` and through incur's own MCP server as `<group>_<tool>`.
+
 ### Serve CLIs as APIs
 
 The inverse of mounting — expose your CLI as a standard Fetch API handler with `cli.fetch`. Works with Bun, Cloudflare Workers, Deno, Hono, and anything that accepts `(req: Request) => Response`.

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -70,6 +70,28 @@ test('fetch command accepts OpenAPI object and URL sources', () => {
   })
 })
 
+test('command accepts MCP string URL and object sources', () => {
+  const cli = Cli.create('test')
+  const fetch = () => new Response()
+
+  cli.command('docsString', {
+    mcp: 'https://mcp.example.com/mcp',
+  })
+
+  cli.command('docsUrl', {
+    mcp: new URL('https://mcp.example.com/mcp'),
+  })
+
+  cli.command('docsObject', {
+    mcp: {
+      url: new URL('https://mcp.example.com/mcp'),
+      headers: { authorization: 'Bearer token' },
+      fetch,
+    },
+    outputPolicy: 'agent-only',
+  })
+})
+
 test('root fetch accepts hosted request sources with OpenAPI paths', () => {
   Cli.create('test', {
     fetch: Fetch.fromRequest('https://api.example.com'),

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -28,6 +28,7 @@ import { detectRunner } from './internal/pm.js'
 import type { OneOf } from './internal/types.js'
 import * as Yaml from './internal/yaml.js'
 import * as Mcp from './Mcp.js'
+import * as McpSource from './McpSource.js'
 import type { Context as MiddlewareContext, Handler as MiddlewareHandler } from './middleware.js'
 import * as Openapi from './Openapi.js'
 export type { MiddlewareHandler }
@@ -96,6 +97,15 @@ export type Cli<
         fetch: FetchSource
         openapi?: Openapi.OpenAPISource | undefined
         openapiConfig?: Openapi.Config | undefined
+        outputPolicy?: OutputPolicy | undefined
+      },
+    ): Cli<commands, vars, env, globals>
+    /** Mounts a remote MCP server as a command group. */
+    <const name extends string>(
+      name: name,
+      definition: {
+        description?: string | undefined
+        mcp: McpSource.Source
         outputPolicy?: OutputPolicy | undefined
       },
     ): Cli<commands, vars, env, globals>
@@ -269,6 +279,23 @@ export function create(
 
     command(nameOrCli: any, def?: any): any {
       if (typeof nameOrCli === 'string') {
+        if (isMcpSourceDefinition(def)) {
+          pending.push(
+            (async () => {
+              const resolved = await McpSource.resolve(def.mcp)
+              const generated = McpSource.generateCommands(def.mcp, resolved)
+              const entry = {
+                _group: true,
+                description: def.description,
+                commands: generated as Map<string, CommandEntry>,
+                ...(def.outputPolicy ? { outputPolicy: def.outputPolicy } : undefined),
+              } as InternalGroup
+              assertNoGlobalOptionConflicts(nameOrCli, entry, toGlobals.get(cli))
+              commands.set(nameOrCli, entry)
+            })(),
+          )
+          return cli
+        }
         if (def && 'fetch' in def && isFetchSource(def.fetch)) {
           const fetch = resolveFetch(def.fetch)
           // OpenAPI + fetch → generate typed command group (async, resolved before serve)
@@ -2919,6 +2946,17 @@ function isFetchSource(value: unknown): value is FetchSource {
 
   const source = value as { fetch?: unknown; url?: unknown }
   return typeof source.fetch === 'function' && source.url instanceof URL
+}
+
+function isMcpSourceDefinition(value: unknown): value is {
+  description?: string | undefined
+  mcp: McpSource.Source
+  outputPolicy?: OutputPolicy | undefined
+} {
+  if (typeof value !== 'object' || value === null || !('mcp' in value)) return false
+  const source = (value as { mcp?: unknown }).mcp
+  if (typeof source === 'string' || source instanceof URL) return true
+  return typeof source === 'object' && source !== null && 'url' in source
 }
 
 function resolveFetch(source: FetchSource): FetchHandler {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -283,7 +283,7 @@ export function create(
           pending.push(
             (async () => {
               const resolved = await McpSource.resolve(def.mcp)
-              const generated = McpSource.generateCommands(def.mcp, resolved)
+              const generated = McpSource.generateCommands(resolved)
               const entry = {
                 _group: true,
                 description: def.description,

--- a/src/McpSource.test.ts
+++ b/src/McpSource.test.ts
@@ -224,6 +224,7 @@ describe('remote MCP command sources', () => {
       {
         "session": {
           "fetch": [Function],
+          "initialized": true,
           "url": "https://example.com/mcp",
         },
         "tools": [

--- a/src/McpSource.test.ts
+++ b/src/McpSource.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from 'vitest'
+import { z } from 'zod'
+
+import * as Cli from './Cli.js'
+import * as McpSource from './McpSource.js'
+
+function serve(cli: { serve: Cli.Cli['serve'] }, argv: string[]) {
+  let output = ''
+  let exitCode: number | undefined
+  return cli
+    .serve(argv, {
+      stdout: (s) => (output += s),
+      exit: (c) => {
+        exitCode = c
+      },
+    })
+    .then(() => ({ output, exitCode }))
+}
+
+function json(output: string) {
+  return JSON.parse(output.replace(/"duration": "[^"]+"/g, '"duration": "<stripped>"'))
+}
+
+function createRemoteCli() {
+  return Cli.create('remote', { version: '1.0.0' })
+    .command('search', {
+      description: 'Search docs',
+      options: z.object({
+        query: z.string().describe('Search query'),
+        limit: z.coerce.number().optional().describe('Result limit'),
+      }),
+      output: z.object({ query: z.string(), limit: z.number().optional() }),
+      run: (context) => context.options,
+    })
+    .command('fail', {
+      options: z.object({ message: z.string() }),
+      run: (context) => context.error({ code: 'REMOTE', message: context.options.message }),
+    })
+}
+
+function mountRemote(remote = createRemoteCli()) {
+  return Cli.create('local').command('docs', {
+    description: 'Docs tools',
+    mcp: { url: new URL('http://mcp.local/mcp'), fetch: (request) => remote.fetch(request) },
+  })
+}
+
+describe('remote MCP command sources', () => {
+  test('mounts remote MCP tools as subcommands', async () => {
+    const cli = mountRemote()
+
+    const result = await serve(cli, [
+      'docs',
+      'search',
+      '--query',
+      'tempo',
+      '--limit',
+      '2',
+      '--json',
+    ])
+
+    expect({ exitCode: result.exitCode, body: json(result.output) }).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "limit": 2,
+          "query": "tempo",
+        },
+        "exitCode": undefined,
+      }
+    `)
+  })
+
+  test('proxies generated subcommands through cli.fetch', async () => {
+    const cli = mountRemote()
+    const response = await cli.fetch(
+      new Request('http://localhost/docs/search', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ query: 'tempo', limit: 3 }),
+      }),
+    )
+    const body = await response.json()
+    body.meta.duration = '<stripped>'
+
+    expect({ status: response.status, body }).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "data": {
+            "limit": 3,
+            "query": "tempo",
+          },
+          "meta": {
+            "command": "docs search",
+            "duration": "<stripped>",
+          },
+          "ok": true,
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('preserves remote tool schemas on generated commands', async () => {
+    const cli = mountRemote()
+
+    const result = await serve(cli, ['docs', 'search', '--help'])
+
+    expect(result.output).toMatchInlineSnapshot(`
+      "local docs search — Search docs\n\nUsage: local docs search [options]\n\nOptions:\n  --query <string>  Search query\n  --limit <number>  Result limit\n\nGlobal Options:\n  --filter-output <keys>              Filter output by key paths (e.g. foo,bar.baz,a[0,3])\n  --format <toon|json|yaml|md|jsonl>  Output format\n  --full-output                       Show full output envelope\n  --help                              Show help\n  --llms, --llms-full                 Print LLM-readable manifest\n  --schema                            Show JSON Schema for command\n  --token-count                       Print token count of output (instead of output)\n  --token-limit <n>                   Limit output to n tokens\n  --token-offset <n>                  Skip first n tokens of output\n"
+    `)
+  })
+
+  test('propagates remote MCP tool errors', async () => {
+    const cli = mountRemote()
+
+    const result = await serve(cli, ['docs', 'fail', '--message', 'boom', '--json'])
+
+    expect({ exitCode: result.exitCode, body: json(result.output) }).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "code": "MCP_TOOL_ERROR",
+          "message": "boom",
+        },
+        "exitCode": 1,
+      }
+    `)
+  })
+
+  test('re-exposes proxied tools through MCP with group name prefixes', async () => {
+    const cli = mountRemote()
+    const response = await cli.fetch(
+      new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json, text/event-stream',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      }),
+    )
+
+    expect(await response.json()).toMatchInlineSnapshot(`
+      {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "result": {
+          "tools": [
+            {
+              "execution": {
+                "taskSupport": "forbidden",
+              },
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "message",
+                ],
+                "type": "object",
+              },
+              "name": "docs_fail",
+            },
+            {
+              "description": "Search docs",
+              "execution": {
+                "taskSupport": "forbidden",
+              },
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "properties": {
+                  "limit": {
+                    "description": "Result limit",
+                    "type": "number",
+                  },
+                  "query": {
+                    "description": "Search query",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "query",
+                ],
+                "type": "object",
+              },
+              "name": "docs_search",
+              "outputSchema": {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "type": "number",
+                  },
+                  "query": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "query",
+                ],
+                "type": "object",
+              },
+            },
+          ],
+        },
+      }
+    `)
+  })
+
+  test('parses text/event-stream JSON-RPC responses', async () => {
+    const fetch = async (request: Request) => {
+      const message = await request.json()
+      if (message.method === 'tools/list')
+        return new Response(
+          `event: message\ndata: {"jsonrpc":"2.0","id":"other","result":{}}\n\ndata: {"jsonrpc":"2.0","id":"${message.id}","result":{"tools":[{"name":"echo"}]}}\n\n`,
+          { headers: { 'content-type': 'text/event-stream' } },
+        )
+      return Response.json({ jsonrpc: '2.0', id: message.id, result: {} })
+    }
+
+    await expect(McpSource.resolve({ url: 'https://example.com/mcp', fetch })).resolves
+      .toMatchInlineSnapshot(`
+      {
+        "session": {
+          "fetch": [Function],
+          "url": "https://example.com/mcp",
+        },
+        "tools": [
+          {
+            "name": "echo",
+          },
+        ],
+      }
+    `)
+  })
+})

--- a/src/McpSource.ts
+++ b/src/McpSource.ts
@@ -1,0 +1,213 @@
+import { z } from 'zod'
+
+import type * as Fetch from './Fetch.js'
+import * as Openapi from './Openapi.js'
+
+const protocolVersion = '2025-06-18'
+
+/** A remote MCP streamable-HTTP server source. */
+export type Source =
+  | string
+  | URL
+  | {
+      /** Streamable-HTTP MCP endpoint URL. */
+      url: string | URL
+      /** Headers merged into every MCP request. */
+      headers?: HeadersInit | undefined
+      /** Fetch handler used for MCP requests. Defaults to `globalThis.fetch`. */
+      fetch?: Fetch.Handler | undefined
+    }
+
+/** A resolved remote MCP server. */
+export type Resolved = {
+  /** Tools returned by `tools/list`. */
+  tools: Tool[]
+  /** Session state reused for later MCP calls. */
+  session: Session
+}
+
+/** Remote MCP session state. */
+export type Session = {
+  /** Fetch handler used for MCP requests. */
+  fetch: Fetch.Handler
+  /** Headers merged into every MCP request. */
+  headers?: HeadersInit | undefined
+  /** Last captured MCP session ID. */
+  id?: string | undefined
+  /** Streamable-HTTP MCP endpoint URL. */
+  url: URL
+}
+
+/** Remote MCP tool metadata. */
+export type Tool = {
+  /** Tool name. */
+  name: string
+  /** Tool description. */
+  description?: string | undefined
+  /** JSON Schema for tool input. */
+  inputSchema?: Record<string, unknown> | undefined
+  /** JSON Schema for tool output. */
+  outputSchema?: Record<string, unknown> | undefined
+}
+
+type Message = { id?: number | string; result?: any; error?: { message?: string; code?: unknown } }
+type ContentItem = { type?: string; text?: string }
+
+/** Resolves a remote MCP server by initializing it and listing its tools. */
+export async function resolve(source: Source, options: resolve.Options = {}): Promise<Resolved> {
+  const session = sourceSession(source)
+  await request(session, 'initialize', {
+    protocolVersion,
+    capabilities: {},
+    clientInfo: { name: 'incur', version: options.version ?? '1.0.0' },
+  })
+  await request(session, 'notifications/initialized')
+  const result = await request(session, 'tools/list')
+  return { tools: (result.tools ?? []) as Tool[], session }
+}
+
+/** Options for resolving a remote MCP server. */
+export declare namespace resolve {
+  /** Remote MCP resolve options. */
+  type Options = {
+    /** Client version reported during MCP initialization. */
+    version?: string | undefined
+  }
+}
+
+/** Generates incur command entries from remote MCP tools. */
+export function generateCommands(source: Source, resolved: Resolved): Map<string, GeneratedEntry> {
+  const commands = new Map<string, GeneratedEntry>()
+  let initialized: Promise<Resolved> | undefined
+  const getResolved = () => (initialized ??= Promise.resolve(resolved))
+
+  for (const tool of resolved.tools) {
+    const options = tool.inputSchema ? inputOptions(tool.inputSchema) : undefined
+    const output = outputSchema(tool.outputSchema)
+    commands.set(tool.name, {
+      description: tool.description,
+      ...(options ? { options } : undefined),
+      ...(output ? { output } : undefined),
+      async run(context) {
+        const current = await getResolved()
+        const result = await request(current.session, 'tools/call', {
+          name: tool.name,
+          arguments: { ...context.args, ...context.options },
+        })
+        if (result.isError)
+          return context.error({ code: 'MCP_TOOL_ERROR', message: resultText(result) })
+        return resultValue(result)
+      },
+    })
+  }
+
+  void source
+  return commands
+}
+
+/** Generated command entry for a remote MCP tool. */
+export type GeneratedEntry = {
+  /** Command description. */
+  description?: string | undefined
+  /** Options schema generated from the MCP tool input schema. */
+  options?: z.ZodObject<any> | undefined
+  /** Output schema generated from the MCP tool output schema. */
+  output?: z.ZodType | undefined
+  /** Proxies a command invocation to `tools/call`. */
+  run(context: any): Promise<unknown>
+}
+
+function sourceSession(source: Source): Session {
+  if (typeof source === 'string' || source instanceof URL)
+    return { url: new URL(source), fetch: globalThis.fetch.bind(globalThis) }
+  return {
+    url: new URL(source.url),
+    fetch: source.fetch ?? globalThis.fetch.bind(globalThis),
+    ...(source.headers ? { headers: source.headers } : undefined),
+  }
+}
+
+async function request(session: Session, method: string, params?: unknown) {
+  const notification = method.startsWith('notifications/')
+  const id = notification ? undefined : crypto.randomUUID()
+  const headers = new Headers(session.headers)
+  headers.set('content-type', 'application/json')
+  headers.set('accept', 'application/json, text/event-stream')
+  if (session.id) headers.set('mcp-session-id', session.id)
+  if (session.id) headers.set('MCP-Protocol-Version', protocolVersion)
+
+  const body = JSON.stringify({ jsonrpc: '2.0', ...(id ? { id } : undefined), method, params })
+  const response = await session.fetch(new Request(session.url, { method: 'POST', headers, body }))
+  const sessionId = response.headers.get('mcp-session-id')
+  if (sessionId) session.id = sessionId
+  if (!response.ok) throw new Error(`MCP HTTP ${response.status}`)
+  if (notification && response.status === 202) return {}
+  const text = await response.text()
+  if (!text) return {}
+  const contentType = response.headers.get('content-type') ?? ''
+  const message = contentType.includes('text/event-stream')
+    ? parseSse(text, id)
+    : (JSON.parse(text) as Message)
+  if (message.error) throw new Error(message.error.message ?? 'MCP request failed')
+  return message.result ?? {}
+}
+
+function parseSse(text: string, id: string | undefined): Message {
+  for (const event of text.split(/\r?\n\r?\n/)) {
+    const data = event
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trimStart())
+      .join('\n')
+    if (!data) continue
+    const message = JSON.parse(data) as Message
+    if (id === undefined || message.id === id) return message
+  }
+  throw new Error('MCP SSE response did not include the matching JSON-RPC message')
+}
+
+function inputOptions(schema: Record<string, unknown>) {
+  const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>
+  const required = new Set((schema.required as string[] | undefined) ?? [])
+  const shape: Record<string, z.ZodType> = {}
+  for (const [key, property] of Object.entries(properties)) {
+    let zodType = Openapi.toZod(property)
+    if (!required.has(key)) zodType = zodType.optional()
+    if (typeof property.description === 'string') zodType = zodType.describe(property.description)
+    shape[key] = Openapi.coerceIfNeeded(zodType)
+  }
+  return Object.keys(shape).length > 0 ? z.object(shape) : undefined
+}
+
+function outputSchema(schema: Record<string, unknown> | undefined) {
+  if (!schema || schema.type !== 'object') return undefined
+  try {
+    return z.fromJSONSchema(schema)
+  } catch {
+    return undefined
+  }
+}
+
+function resultText(result: any) {
+  const content = Array.isArray(result.content) ? (result.content as ContentItem[]) : []
+  return content
+    .map((item) => (item.type === 'text' ? item.text : ''))
+    .filter(Boolean)
+    .join('\n')
+}
+
+function resultValue(result: any) {
+  if (result.structuredContent !== undefined) return result.structuredContent
+  const content = Array.isArray(result.content) ? (result.content as ContentItem[]) : []
+  const textItems = content
+    .filter((item): item is { type?: string; text: string } => item.type === 'text')
+    .map((item) => item.text)
+  if (textItems.length === 1) {
+    try {
+      return JSON.parse(textItems[0]!)
+    } catch {
+      return textItems[0]!
+    }
+  }
+  return textItems
+}

--- a/src/McpSource.ts
+++ b/src/McpSource.ts
@@ -34,6 +34,8 @@ export type Session = {
   headers?: HeadersInit | undefined
   /** Last captured MCP session ID. */
   id?: string | undefined
+  /** Whether the server completed initialization. */
+  initialized?: boolean | undefined
   /** Streamable-HTTP MCP endpoint URL. */
   url: URL
 }
@@ -61,6 +63,7 @@ export async function resolve(source: Source, options: resolve.Options = {}): Pr
     capabilities: {},
     clientInfo: { name: 'incur', version: options.version ?? '1.0.0' },
   })
+  session.initialized = true
   await request(session, 'notifications/initialized')
   const result = await request(session, 'tools/list')
   return { tools: (result.tools ?? []) as Tool[], session }
@@ -76,10 +79,8 @@ export declare namespace resolve {
 }
 
 /** Generates incur command entries from remote MCP tools. */
-export function generateCommands(source: Source, resolved: Resolved): Map<string, GeneratedEntry> {
+export function generateCommands(resolved: Resolved): Map<string, GeneratedEntry> {
   const commands = new Map<string, GeneratedEntry>()
-  let initialized: Promise<Resolved> | undefined
-  const getResolved = () => (initialized ??= Promise.resolve(resolved))
 
   for (const tool of resolved.tools) {
     const options = tool.inputSchema ? inputOptions(tool.inputSchema) : undefined
@@ -89,8 +90,7 @@ export function generateCommands(source: Source, resolved: Resolved): Map<string
       ...(options ? { options } : undefined),
       ...(output ? { output } : undefined),
       async run(context) {
-        const current = await getResolved()
-        const result = await request(current.session, 'tools/call', {
+        const result = await request(resolved.session, 'tools/call', {
           name: tool.name,
           arguments: { ...context.args, ...context.options },
         })
@@ -101,7 +101,6 @@ export function generateCommands(source: Source, resolved: Resolved): Map<string
     })
   }
 
-  void source
   return commands
 }
 
@@ -134,7 +133,7 @@ async function request(session: Session, method: string, params?: unknown) {
   headers.set('content-type', 'application/json')
   headers.set('accept', 'application/json, text/event-stream')
   if (session.id) headers.set('mcp-session-id', session.id)
-  if (session.id) headers.set('MCP-Protocol-Version', protocolVersion)
+  if (session.initialized) headers.set('MCP-Protocol-Version', protocolVersion)
 
   const body = JSON.stringify({ jsonrpc: '2.0', ...(id ? { id } : undefined), method, params })
   const response = await session.fetch(new Request(session.url, { method: 'POST', headers, body }))

--- a/src/Openapi.ts
+++ b/src/Openapi.ts
@@ -746,12 +746,12 @@ function createHandler(config: {
 }
 
 /** Converts a JSON Schema object to a Zod schema. */
-function toZod(schema: Record<string, unknown>): z.ZodType {
+export function toZod(schema: Record<string, unknown>): z.ZodType {
   return z.fromJSONSchema(schema)
 }
 
 /** Wraps a Zod schema with coercion if the base type is number or boolean (argv is always strings). */
-function coerceIfNeeded(schema: z.ZodType): z.ZodType {
+export function coerceIfNeeded(schema: z.ZodType): z.ZodType {
   const isOptional = schema instanceof z.ZodOptional
   const inner = isOptional ? schema.unwrap() : schema
 


### PR DESCRIPTION
Adds remote MCP servers as command sources: `cli.command('docs', { mcp: 'https://…/mcp' })` lists server tools and mounts them as proxied subcommands across CLI, HTTP, and MCP surfaces.
