### PR TITLE
feat: add gcf output format

### DIFF
--- a/.changeset/gcf-output-format.md
+++ b/.changeset/gcf-output-format.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Added `gcf` as an output format (`--format gcf`) alongside `toon`, `json`, `yaml`, `md`, and `jsonl`. GCF (Graph Compact Format) is a lossless, zero-runtime-dependency encoding for structured data.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "SKILL.md"
   ],
   "dependencies": {
+    "@blackwell-systems/gcf": "^2.4.0",
     "@cfworker/json-schema": "^4.1.1",
     "@modelcontextprotocol/server": "^2.0.0-alpha.2",
     "@scalar/openapi-types": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "SKILL.md"
   ],
   "dependencies": {
-    "@blackwell-systems/gcf": "^2.4.0",
+    "@blackwell-systems/gcf": "2.4.0",
     "@cfworker/json-schema": "^4.1.1",
     "@modelcontextprotocol/server": "^2.0.0-alpha.2",
     "@scalar/openapi-types": "^0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@blackwell-systems/gcf':
-        specifier: ^2.4.0
+        specifier: 2.4.0
         version: 2.4.0
       '@cfworker/json-schema':
         specifier: ^4.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@blackwell-systems/gcf':
+        specifier: ^2.4.0
+        version: 2.4.0
       '@cfworker/json-schema':
         specifier: ^4.1.1
         version: 4.1.1
@@ -111,6 +114,10 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@blackwell-systems/gcf@2.4.0':
+    resolution: {integrity: sha512-lLEZCzNMYVk630iaVVPPhcQtmCjhPRETRlwk/JAptGE0SEL6ZMHfA9HZPornuMvvpGeyrimRjj9Yb2nYQNS1og==}
+    hasBin: true
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -1503,6 +1510,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@blackwell-systems/gcf@2.4.0': {}
 
   '@cfworker/json-schema@4.1.1': {}
 

--- a/src/Cli.test-d.ts
+++ b/src/Cli.test-d.ts
@@ -271,7 +271,7 @@ test('middleware() without generic gives empty context', () => {
   middleware((c, _next) => {
     expectTypeOf(c.var).toEqualTypeOf<{}>()
     expectTypeOf(c.env).toEqualTypeOf<{}>()
-    expectTypeOf(c.format).toEqualTypeOf<'toon' | 'json' | 'yaml' | 'md' | 'jsonl'>()
+    expectTypeOf(c.format).toEqualTypeOf<'toon' | 'json' | 'yaml' | 'md' | 'jsonl' | 'gcf'>()
     expectTypeOf(c.formatExplicit).toEqualTypeOf<boolean>()
   })
 })
@@ -367,7 +367,7 @@ test('run() context exposes format metadata', () => {
   const cli = Cli.create('test')
   cli.command('ping', {
     run(c) {
-      expectTypeOf(c.format).toEqualTypeOf<'toon' | 'json' | 'yaml' | 'md' | 'jsonl'>()
+      expectTypeOf(c.format).toEqualTypeOf<'toon' | 'json' | 'yaml' | 'md' | 'jsonl' | 'gcf'>()
       expectTypeOf(c.formatExplicit).toEqualTypeOf<boolean>()
       return { pong: true }
     },

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -2480,7 +2480,7 @@ declare namespace serveImpl {
 }
 
 /** @internal Extracts built-in flags (--full-output, --format, --json, --llms, --help, --version) from argv. */
-const validFormats = new Set(['toon', 'json', 'yaml', 'md', 'jsonl'] as const)
+const validFormats = new Set(['toon', 'json', 'yaml', 'md', 'jsonl', 'gcf'] as const)
 
 function extractBuiltinFlags(argv: string[], options: extractBuiltinFlags.Options = {}) {
   let fullOutput = false

--- a/src/Formatter.test.ts
+++ b/src/Formatter.test.ts
@@ -1,3 +1,4 @@
+import { decodeGeneric } from '@blackwell-systems/gcf'
 import { decode } from '@toon-format/toon'
 import { Formatter } from 'incur'
 
@@ -51,6 +52,41 @@ describe('format', () => {
   test('formats as TOON (explicit)', () => {
     const result = Formatter.format({ message: 'hello' }, 'toon')
     expect(result).toMatchInlineSnapshot(`"message: hello"`)
+  })
+
+  test('formats as GCF (explicit)', () => {
+    const result = Formatter.format({ message: 'hello' }, 'gcf')
+    expect(result).toBe('GCF profile=generic\nmessage=hello\n')
+  })
+
+  test('formats an array of records as a GCF table', () => {
+    const result = Formatter.format(
+      {
+        ok: true,
+        data: {
+          users: [
+            { id: 1, name: 'a' },
+            { id: 2, name: 'b' },
+          ],
+        },
+        meta: { command: 'users' },
+      },
+      'gcf',
+    )
+    expect(result).toBe(
+      'GCF profile=generic\nok=true\n## data\n  ## users [2]{id,name}\n  1|a\n  2|b\n## meta\n  command=users\n',
+    )
+  })
+
+  test('round-trips through GCF decode', () => {
+    const envelope = {
+      ok: true,
+      data: { items: [1, 2, 3] },
+      meta: { command: 'list', duration: '5ms' },
+    }
+
+    const result = decodeGeneric(Formatter.format(envelope, 'gcf'))
+    expect(result).toMatchObject(envelope)
   })
 
   test('formats as JSON', () => {

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -1,10 +1,11 @@
+import { encodeGeneric } from '@blackwell-systems/gcf'
 import { encode } from '@toon-format/toon'
 
 import * as Json from './internal/json.js'
 import * as Yaml from './internal/yaml.js'
 
 /** Supported output formats. */
-export type Format = 'toon' | 'json' | 'yaml' | 'md' | 'jsonl'
+export type Format = 'toon' | 'json' | 'yaml' | 'md' | 'jsonl' | 'gcf'
 
 /** Serializes a value to the specified format. Defaults to TOON. */
 export function format(value: unknown, fmt: Format = 'toon'): string {
@@ -25,6 +26,10 @@ export function format(value: unknown, fmt: Format = 'toon'): string {
   if (fmt === 'jsonl') {
     if (Array.isArray(value)) return value.map((v) => Json.stringify(v)).join('\n')
     return Json.stringify(value)
+  }
+  if (fmt === 'gcf') {
+    if (isScalar(value)) return String(value)
+    return encodeGeneric(value)
   }
   // toon (default)
   if (isScalar(value)) return String(value)

--- a/src/Help.ts
+++ b/src/Help.ts
@@ -407,7 +407,7 @@ function globalOptionsLines(
       flag: '--filter-output <keys>',
       desc: 'Filter output by key paths (e.g. foo,bar.baz,a[0,3])',
     },
-    { flag: '--format <toon|json|yaml|md|jsonl>', desc: 'Output format' },
+    { flag: '--format <toon|json|yaml|md|jsonl|gcf>', desc: 'Output format' },
     { flag: '--help', desc: 'Show help' },
     { flag: '--llms, --llms-full', desc: 'Print LLM-readable manifest' },
     ...(root ? [{ flag: '--mcp', desc: 'Start as MCP stdio server' }] : []),


### PR DESCRIPTION
Adds `gcf` as an output format alongside `toon`, `json`, `yaml`, `md`, and `jsonl`. One branch in `Formatter.format()`, mirroring the existing TOON path. Opt-in via `--format gcf`; TOON stays the default and is untouched.

## Why

TOON re-declares a nested object's schema on every row, so on nested tool/API responses it can encode *larger than raw JSON*. GCF path-flattens nested fields, so it ties TOON on flat records and is materially smaller on nested ones, while round-tripping losslessly.

Benchmark (40-record nested API response — the shape incur-wrapped OpenAPI/MCP tools return; o200k, GCF round-trip verified lossless):

| format | tokens |
|--------|--------|
| JSON | 3548 |
| TOON (current default) | 4288 |
| **GCF** | **2453** |

GCF is **−30.9% vs JSON** and **−42.8% vs TOON**; TOON runs **+20.9% larger than JSON** on nested payloads. On flat uniform records GCF ties TOON (both ~30% below JSON).

## Comprehension (the part that matters for an agent framework)

The tokens saved don't cost the agent any accuracy. On a generic-profile comprehension eval — 500 orders with nested customer objects and line items, 13 structured-extraction questions, zero format instructions, deterministic answers (no LLM judge), 27 runs across 11 models — GCF scores **100% on every frontier model** (Claude Opus/Sonnet/Haiku 4.x, GPT-5.5, Gemini 2.5 Pro / 3.x) and **leads on smaller models** (Gemini 2.5 Flash: GCF 95.0% vs TOON 85.1% vs JSON 74.0%; Mistral Medium 3.5: GCF 82.7% vs TOON 76.9%). That workload — arrays of objects with nested metadata — is exactly what a CLI-wrapped tool response looks like. Agents read GCF at least as accurately as JSON, and more accurately than TOON where accuracy is scarce. Full data: https://gcformat.com/guide/benchmarks

## Correctness

GCF round-trips losslessly by design. For contrast, a 100k-case fuzz of the reference `@toon-format/toon` shows a 7.47% round-trip failure rate (1.73% of it silent, no error thrown), reproducible via [`eval/toon-fuzz.mjs`](https://github.com/blackwell-systems/gcf/blob/main/eval/toon-fuzz.mjs). `@blackwell-systems/gcf` is MIT with zero runtime dependencies.

## In production elsewhere

GCF ships as an opt-in format in Chrome DevTools MCP, is vendored into [OmniRoute](https://github.com/diegosouzapw/OmniRoute)'s compression engine, replaced TOON in [NetClaw](https://github.com/automateyournetwork/netclaw), and was merged into [Speakeasy's `oq`](https://github.com/speakeasy-api/openapi/pull/216). Full list: [gcformat.com/ecosystem/adopters](https://gcformat.com/ecosystem/adopters.html).

## Format + research

Spec and playground at [gcformat.com](https://gcformat.com) ([vs-TOON](https://gcformat.com/guide/vs-toon.html), [benchmarks](https://gcformat.com/guide/benchmarks)); the format and its underlying tokenizer/attention research are documented in the [whitepaper](https://github.com/blackwell-systems/gcf/blob/main/gcf-whitepaper.pdf) (DOI [10.5281/zenodo.20579817](https://doi.org/10.5281/zenodo.20579817)).

Additive and opt-in; happy to adjust naming, placement, or scope to fit the project's conventions.

