### PR TITLE
fix(skills): compare resolved paths before replacing an agent directory

### DIFF
--- a/.changeset/alias-skills-dir.md
+++ b/.changeset/alias-skills-dir.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Fixed `skills add` deleting the skill it had just installed, and replacing it with a self-referential symlink, when an agent's skills directory is a symlink to the canonical one.

--- a/src/internal/agents.test.ts
+++ b/src/internal/agents.test.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, lstatSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as Agents from './agents.js'
+
+function scaffold() {
+  const dir = mkdtempSync(join(tmpdir(), 'clac-agents-'))
+  const source = join(dir, 'source')
+  mkdirSync(join(source, 'demo'), { recursive: true })
+  writeFileSync(join(source, 'demo', 'SKILL.md'), 'name: demo\ndescription: d\n')
+  return { dir, source }
+}
+
+const claude: Agents.Agent = {
+  name: 'Claude Code',
+  globalSkillsDir: '/unused',
+  projectSkillsDir: '.claude/skills',
+  universal: false,
+  detect: () => true,
+}
+
+test('installs a skill as a real directory', () => {
+  const { dir, source } = scaffold()
+
+  Agents.install(source, { global: false, cwd: dir, agents: [claude] })
+
+  const installed = join(dir, '.agents', 'skills', 'demo')
+  expect(lstatSync(installed).isDirectory()).toBe(true)
+  expect(readFileSync(join(installed, 'SKILL.md'), 'utf8')).toContain('name: demo')
+
+  rmSync(dir, { recursive: true, force: true })
+})
+
+// An agent whose skills directory is a symlink to the canonical one names the same directory by a
+// different path. Comparing the two as strings let the agent pass delete the skill just written and
+// replace it with a link pointing at itself.
+test('an agent directory aliased to the canonical one is left alone', () => {
+  const { dir, source } = scaffold()
+  const canonical = join(dir, '.agents', 'skills')
+  mkdirSync(canonical, { recursive: true })
+  mkdirSync(join(dir, '.claude'), { recursive: true })
+  symlinkSync(canonical, join(dir, '.claude', 'skills'))
+
+  // Something unrelated already living there must survive.
+  mkdirSync(join(canonical, 'existing'), { recursive: true })
+  writeFileSync(join(canonical, 'existing', 'SKILL.md'), 'name: existing\n')
+
+  Agents.install(source, { global: false, cwd: dir, agents: [claude] })
+
+  const installed = join(canonical, 'demo')
+  expect(lstatSync(installed).isSymbolicLink()).toBe(false)
+  expect(readFileSync(join(installed, 'SKILL.md'), 'utf8')).toContain('name: demo')
+  expect(readFileSync(join(canonical, 'existing', 'SKILL.md'), 'utf8')).toContain('name: existing')
+
+  rmSync(dir, { recursive: true, force: true })
+})

--- a/src/internal/agents.ts
+++ b/src/internal/agents.ts
@@ -217,8 +217,11 @@ export function install(sourceDir: string, options: install.Options = {}): insta
         : path.join(cwd, agent.projectSkillsDir)
       const agentDir = path.join(agentSkillsDir, skill.name)
 
-      // Skip if agent dir resolves to canonical (no symlink needed)
-      if (agentDir === canonicalDir) continue
+      // Skip if agent dir resolves to canonical (no symlink needed). Compared after resolving, because
+      // an agent whose skills directory is a symlink to the canonical one names the same directory by a
+      // different path. Removing it there would delete the skill just written, and the replacement link
+      // would point at itself.
+      if (resolveParent(agentDir) === resolveParent(canonicalDir)) continue
 
       try {
         rmForce(agentDir)


### PR DESCRIPTION
`install` skipped the per-agent symlink when the agent's skills directory already was the canonical one, but compared the two paths as strings. An agent whose skills directory is a symlink to the canonical one, such as `~/.claude/skills` pointing at `~/.agents/skills`, names the same directory by a different path, so the guard never fired.

Each skill was then copied to the canonical location, immediately deleted through the alias, and replaced with a symlink pointing at itself: `~/.agents/skills/frog -> frog`. `skills list` reported the skills as present but zero installed.

Compares resolved paths using the `resolveParent` helper already in the file, which resolves the parent when the directory does not exist yet.
