### PR TITLE
chore: mark binary changeset as patch

### DIFF
--- a/.changeset/curvy-frogs-update.md
+++ b/.changeset/curvy-frogs-update.md
@@ -1,5 +1,5 @@
 ---
-'incur': minor
+'incur': patch
 ---
 
 Added cross-platform binary distribution, and update notices


### PR DESCRIPTION
Changes the standalone binary distribution changeset from minor to patch, keeping the release impact aligned with the requested non-breaking version bump.