### PR TITLE
fix: install Alpine runtime libraries

### DIFF
--- a/.changeset/tiny-dingos-smoke.md
+++ b/.changeset/tiny-dingos-smoke.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Fixed Alpine smoke tests for Bun musl binaries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@
 - **Prepare release targets** — create a missing inferred `v<version>` tag and draft release, or reuse a matching mutable release; reject pull request refs and never move tags or replace assets.
 - **Trust action release inputs** — install, build, and upload share one job's write permission; `persist-credentials: false` does not create a permission boundary.
 - **Limit smoke tests to the runner** — test only matching-architecture Linux glibc and musl assets; native macOS and Windows tests and signing stay out of scope.
+- **Install musl runtime libraries** — Bun musl executables require `libstdc++` and `libgcc`; install both before Alpine smoke tests.
 - **Test spaced version overrides** — command-local `--version <value>` must not be consumed as the root boolean `--version` flag.
 
 ## Git Conventions

--- a/release/scripts/smoke-linux.sh
+++ b/release/scripts/smoke-linux.sh
@@ -56,32 +56,26 @@ smoke_native() {
 
 smoke_alpine() {
   local binary="$1"
-  local actual_version
   local command
 
   command="/smoke/$(basename "$binary")"
-
   docker run --rm \
+    --env EXPECTED_VERSION \
+    --env "SMOKE_COMMAND=${SMOKE_COMMAND:-}" \
     --volume "$temporary:/smoke:ro" \
     alpine:3.22 \
-    "$command" --help > /dev/null
-  actual_version="$(
-    docker run --rm \
-      --volume "$temporary:/smoke:ro" \
-      alpine:3.22 \
-      "$command" --version
-  )"
-  if [[ "$actual_version" != "$EXPECTED_VERSION" ]]; then
-    printf 'Expected version %s, received %s.\n' \
-      "$EXPECTED_VERSION" "$actual_version" >&2
-    exit 1
-  fi
-  if [[ -n "${SMOKE_COMMAND:-}" ]]; then
-    docker run --rm \
-      --volume "$temporary:/smoke:ro" \
-      alpine:3.22 \
-      "$command" "$SMOKE_COMMAND"
-  fi
+    sh -eu -c '
+      apk add --no-cache libstdc++ libgcc > /dev/null
+      command="$1"
+      "$command" --help > /dev/null
+      actual_version="$("$command" --version)"
+      if [ "$actual_version" != "$EXPECTED_VERSION" ]; then
+        printf "Expected version %s, received %s.\n" \
+          "$EXPECTED_VERSION" "$actual_version" >&2
+        exit 1
+      fi
+      if [ -n "$SMOKE_COMMAND" ]; then "$command" "$SMOKE_COMMAND"; fi
+    ' sh "$command"
 }
 
 command -v docker > /dev/null 2>&1 || {


### PR DESCRIPTION
Install Alpine's C++ runtime libraries before smoke-testing Bun musl executables, allowing the release action to verify and upload the supported musl assets.