### PR TITLE
feat: publish binary releases by default

### DIFF
--- a/.changeset/calm-cats-publish.md
+++ b/.changeset/calm-cats-publish.md
@@ -1,5 +1,5 @@
 ---
-'incur': minor
+'incur': patch
 ---
 
 Published completed standalone binary releases by default and added a `publish` input for draft-first workflows.

--- a/.changeset/calm-cats-publish.md
+++ b/.changeset/calm-cats-publish.md
@@ -1,0 +1,5 @@
+---
+'incur': minor
+---
+
+Published completed standalone binary releases by default and added a `publish` input for draft-first workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@
 - **Release from one Linux action** — run `release@v1` as a step on `ubuntu-latest` with `contents: write`; it cross-compiles unsigned assets for every target.
 - **Infer release action inputs** — default to `./src/bin.ts`, derive the CLI name and stable version, and treat `entry`, `name`, and `release_tag` as overrides.
 - **Prepare release targets** — create a missing inferred `v<version>` tag and draft release, or reuse a matching mutable release; reject pull request refs and never move tags or replace assets.
+- **Publish after upload** — publish by default only after every verified asset uploads successfully, mark it as latest, and support draft-first workflows through explicit opt-out.
 - **Trust action release inputs** — install, build, and upload share one job's write permission; `persist-credentials: false` does not create a permission boundary.
 - **Limit smoke tests to the runner** — test only matching-architecture Linux glibc and musl assets; native macOS and Windows tests and signing stay out of scope.
 - **Install musl runtime libraries** — Bun musl executables require `libstdc++` and `libgcc`; install both before Alpine smoke tests.

--- a/README.md
+++ b/README.md
@@ -884,9 +884,9 @@ jobs:
         uses: wevm/incur/release@v1
 ```
 
-The action defaults to `./src/bin.ts`, reads the name and version from `package.json`, and creates a missing `v<version>` draft or reuses its existing release. Inputs remain available as overrides. Run it only with trusted source and locked dependencies because release preparation, build, and upload share the job's write permission.
+The action defaults to `./src/bin.ts`, reads the name and version from `package.json`, creates or reuses the matching release, uploads verified assets, and publishes it as the latest release. Set `publish: false` for a draft-first workflow. Run it only with trusted source and locked dependencies because release preparation, build, and publication share the job's write permission.
 
-After publishing the draft, users can install without a package manager:
+After the release is published, users can install without a package manager:
 
 ```sh
 curl -fsSL https://github.com/example/my-cli/releases/latest/download/install.sh | sh

--- a/docs/binaries.md
+++ b/docs/binaries.md
@@ -303,20 +303,22 @@ The action:
 8. Tests the matching Linux glibc executable on the runner.
 9. Tests the matching Linux musl executable in Alpine.
 10. Uploads the `.gz` release assets, `SHA256SUMS`, `install.sh`, and `install.ps1`.
-11. Stops if an upload would replace an existing release asset.
+11. Publishes the completed release and marks it as latest unless `publish` is `false`.
+12. Stops if an upload would replace an existing release asset.
 
 The action tests only Linux executables for the runner architecture. It does not
 test other architectures, macOS, or Windows. It does not sign executables.
 
-If Incur creates the release, it leaves the release as a draft. Use this release
-procedure:
+Set `publish: false` to keep a release that Incur creates as a draft. Use this
+release procedure when you want to review its assets:
 
 1. Run the action from the release commit.
 2. Review the release assets.
 3. Publish the draft release.
 
-The action does not publish a release. It does not move an existing tag or
-replace existing assets.
+By default, the action publishes the release after every asset uploads and marks
+it as the latest release. The action does not move an existing tag or replace
+existing assets.
 
 With `changesets/action@v1`, keep the default `createGithubReleases: true`. Run
 Incur after Changesets reports a publication. Incur reuses the published release
@@ -339,6 +341,7 @@ Use these inputs only when you must override a default:
 - Use `pnpm_version` if `package.json` does not specify the pnpm version.
 - Use `bun_version` to select the compiler version.
 - Use `smoke_command` to pass one safe argument to each tested Linux executable.
+- Use `publish: false` to leave the completed release as a draft.
 
 For the draft-first procedure, the action exposes `release_tag` for later steps.
 For example, publish the completed draft with

--- a/release/action.yml
+++ b/release/action.yml
@@ -1,5 +1,5 @@
 name: 'Incur binary release'
-description: 'Build and upload unsigned standalone binaries to a GitHub release'
+description: 'Build and release unsigned standalone binaries on GitHub'
 
 inputs:
   bun_version:
@@ -22,6 +22,10 @@ inputs:
     description: 'pnpm fallback version when packageManager does not declare one'
     required: false
     default: '10.30.2'
+  publish:
+    description: 'Publish the completed release and mark it as latest'
+    required: false
+    default: 'true'
   release_tag:
     description: 'Existing stable release tag override matching v<package version>'
     required: false
@@ -134,13 +138,14 @@ runs:
       shell: bash
       run: bash "$GITHUB_ACTION_PATH/scripts/smoke-linux.sh"
 
-    - name: Revalidate and upload release assets
+    - name: Upload release assets
       env:
         BINARY_NAME: ${{ steps.build.outputs.name }}
         BINARY_OUTPUT: 'dist/binaries'
         EXPECTED_COMMIT: ${{ steps.release.outputs.commit }}
         EXPECTED_RELEASE_ID: ${{ steps.release.outputs.release_id }}
         GH_TOKEN: ${{ github.token }}
+        PUBLISH_RELEASE: ${{ inputs.publish }}
         RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
       shell: bash
       run: bash "$GITHUB_ACTION_PATH/scripts/upload.sh"

--- a/release/scripts/upload.sh
+++ b/release/scripts/upload.sh
@@ -14,6 +14,11 @@ fail() {
   exit 1
 }
 
+publish="${PUBLISH_RELEASE:-true}"
+if [[ "$publish" != 'true' && "$publish" != 'false' ]]; then
+  fail 'publish must be true or false.'
+fi
+
 release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
 
 if [[ "$(jq -r '.id' <<< "$release")" != "$EXPECTED_RELEASE_ID" ]]; then
@@ -68,3 +73,10 @@ for file in "${assets[@]}"; do
 done
 
 gh release upload "$RELEASE_TAG" "${assets[@]}" --repo "$GITHUB_REPOSITORY"
+
+if [[ "$publish" == 'true' ]]; then
+  gh release edit "$RELEASE_TAG" \
+    --draft=false \
+    --latest \
+    --repo "$GITHUB_REPOSITORY"
+fi

--- a/src/internal/binaryRelease.test.ts
+++ b/src/internal/binaryRelease.test.ts
@@ -164,12 +164,12 @@ describe.skipIf(process.platform === 'win32')('upload.sh', () => {
   test.each([
     { draft: true, state: 'draft' },
     { draft: false, state: 'published' },
-  ])('uploads binary assets to a $state release', async ({ draft }) => {
+  ])('leaves a $state release unpublished when opted out', async ({ draft }) => {
     await writeFile(join(state, 'tag-commit'), commit)
     await writeRelease({ draft })
     const assets = await writeAssets()
 
-    await runUpload()
+    await runUpload({ PUBLISH_RELEASE: 'false' })
 
     await expect(calls()).resolves.toContainEqual([
       'release',
@@ -179,6 +179,32 @@ describe.skipIf(process.platform === 'win32')('upload.sh', () => {
       '--repo',
       'wevm/demo',
     ])
+    await expect(calls()).resolves.not.toContainEqual(expect.arrayContaining(['release', 'edit']))
+  })
+
+  test('publishes the completed release as latest by default', async () => {
+    await writeFile(join(state, 'tag-commit'), commit)
+    await writeRelease({ draft: true })
+    const assets = await writeAssets()
+
+    await runUpload()
+
+    const calls_ = await calls()
+    expect(calls_.slice(-2)).toEqual([
+      ['release', 'upload', 'v1.2.3', ...assets, '--repo', 'wevm/demo'],
+      ['release', 'edit', 'v1.2.3', '--draft=false', '--latest', '--repo', 'wevm/demo'],
+    ])
+  })
+
+  test('rejects an invalid publish input before uploading assets', async () => {
+    await writeFile(join(state, 'tag-commit'), commit)
+    await writeRelease({ draft: true })
+    await writeAssets()
+
+    await expect(runUpload({ PUBLISH_RELEASE: 'yes' })).rejects.toMatchObject({
+      stderr: 'publish must be true or false.\n',
+    })
+    await expect(readFile(join(state, 'calls'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   test('does not upload to a release that became immutable', async () => {
@@ -227,7 +253,7 @@ function run(env: NodeJS.ProcessEnv = {}) {
   })
 }
 
-function runUpload() {
+function runUpload(env: NodeJS.ProcessEnv = {}) {
   return exec('bash', [uploadScript], {
     cwd: repository,
     env: {
@@ -241,6 +267,7 @@ function runUpload() {
       GITHUB_REPOSITORY: 'wevm/demo',
       PATH: `${bin}${delimiter}${process.env.PATH}`,
       RELEASE_TAG: 'v1.2.3',
+      ...env,
     },
   })
 }
@@ -340,6 +367,8 @@ if (args[0] === 'release' && args[1] === 'create') {
 }
 
 if (args[0] === 'release' && args[1] === 'upload') process.exit(0)
+
+if (args[0] === 'release' && args[1] === 'edit') process.exit(0)
 
 process.stderr.write('Unexpected gh call: ' + JSON.stringify(args) + '\\n')
 process.exit(1)


### PR DESCRIPTION
Publishes completed binary releases as latest by default after verified asset upload, adds a `publish: false` draft-first opt-out, and documents the updated release action behavior.