### PR TITLE
fix: append binaries to latest release

### DIFF
--- a/.changeset/fuzzy-frogs-append.md
+++ b/.changeset/fuzzy-frogs-append.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Appended standalone binary assets to the latest matching GitHub release, including Changesets workspace releases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,7 @@
 - **Pin generated installers** — a mutable latest-release URL may select an installer, but the generated script must download binary assets from its embedded exact release tag.
 - **Release from one Linux action** — run `release@v1` as a step on `ubuntu-latest` with `contents: write`; it cross-compiles unsigned assets for every target.
 - **Infer release action inputs** — default to `./src/bin.ts`, derive the CLI name and stable version, and treat `entry`, `name`, and `release_tag` as overrides.
-- **Prepare release targets** — create a missing inferred `v<version>` tag and draft release, or reuse a matching mutable release; reject pull request refs and never move tags or replace assets.
-- **Publish after upload** — publish by default only after every verified asset uploads successfully, mark it as latest, and support draft-first workflows through explicit opt-out.
+- **Append to existing releases** — default to the latest published release, require its tag to match the package version, and never create or modify releases or tags.
 - **Trust action release inputs** — install, build, and upload share one job's write permission; `persist-credentials: false` does not create a permission boundary.
 - **Limit smoke tests to the runner** — test only matching-architecture Linux glibc and musl assets; native macOS and Windows tests and signing stay out of scope.
 - **Install musl runtime libraries** — Bun musl executables require `libstdc++` and `libgcc`; install both before Alpine smoke tests.

--- a/docs/binaries.md
+++ b/docs/binaries.md
@@ -82,18 +82,27 @@ pnpm exec incur build ./src/bin.ts \
   --repository wevm/frog
 ```
 
+Pass `--tag` when the assets will use a release tag other than `v<version>`:
+
+```sh
+pnpm exec incur build ./src/bin.ts \
+  --installer \
+  --repository wevm/frog \
+  --tag frog@1.2.3
+```
+
 To generate installers:
 
 - Use a stable semantic version.
 - Build all default targets.
 
 The command adds `install.sh` and `install.ps1` to `dist/binaries/`. Each
-installer contains the exact `v<version>` release tag. A latest-release URL
-selects only the installer. The installer downloads its executable and
-`SHA256SUMS` from the tagged release.
+installer contains the exact release tag. A latest-release URL selects only the
+installer. The installer downloads its executable and `SHA256SUMS` from the
+tagged release.
 
-If the action created a draft, publish it after the asset upload. Users can then
-install the latest stable release:
+After the release action appends the assets, users can install the latest stable
+release:
 
 ```sh
 curl -fsSL https://github.com/wevm/frog/releases/latest/download/install.sh | sh
@@ -274,13 +283,12 @@ The action uses these defaults:
 - The entry point is `./src/bin.ts`.
 - The CLI name comes from the root `package.json`.
 - The version is the stable version in the root `package.json`.
-- The release tag is `v<version>`.
+- The release is the latest published GitHub release.
 
 Before the action runs project code, it reads the package version from the
-triggering commit. It creates a missing inferred tag and draft release at that
-commit. If the tag exists, the action reuses its draft or published release. It
-then checks out the tagged commit, checks the package version, installs
-dependencies, and builds the executables.
+triggering commit and resolves the latest published release. It verifies that
+the release tag identifies that package version, then checks out the tagged
+commit, installs dependencies, and builds the executables.
 
 The job gives `contents: write` to all steps. Composite action steps share the
 job permissions. Use only trusted source and lockfiles.
@@ -294,7 +302,7 @@ request merge refs.
 The action:
 
 1. Requires a public repository and a stable package version.
-2. Creates a missing inferred version tag and draft release, or reuses its mutable release.
+2. Resolves the latest mutable published release for that package version.
 3. Detects npm, pnpm, or Bun.
 4. Installs the project dependencies.
 5. Uses the pinned Bun version to compile all eight unsigned targets on Linux.
@@ -303,49 +311,28 @@ The action:
 8. Tests the matching Linux glibc executable on the runner.
 9. Tests the matching Linux musl executable in Alpine.
 10. Uploads the `.gz` release assets, `SHA256SUMS`, `install.sh`, and `install.ps1`.
-11. Publishes the completed release and marks it as latest unless `publish` is `false`.
-12. Stops if an upload would replace an existing release asset.
+11. Stops if an upload would replace an existing release asset.
 
 The action tests only Linux executables for the runner architecture. It does not
 test other architectures, macOS, or Windows. It does not sign executables.
 
-Set `publish: false` to keep a release that Incur creates as a draft. Use this
-release procedure when you want to review its assets:
-
-1. Run the action from the release commit.
-2. Review the release assets.
-3. Publish the draft release.
-
-By default, the action publishes the release after every asset uploads and marks
-it as the latest release. The action does not move an existing tag or replace
-existing assets.
-
 With `changesets/action@v1`, keep the default `createGithubReleases: true`. Run
-Incur after Changesets reports a publication. Incur reuses the published release
-and uploads its binary assets.
-
-This flow supports one root package, where Changesets uses `v<version>`.
-Changesets workspaces use `<package>@<version>`, which does not match Incur's
-release tag format.
+Incur after Changesets reports a publication. Incur appends binary assets to the
+release that Changesets published, including workspace releases tagged
+`<package>@<version>`.
 
 A published release is visible before its binaries are ready. A failed build can
-leave the release incomplete. Published immutable releases cannot accept new
-assets; use the draft-first procedure when release immutability is enabled.
+leave the release incomplete. Immutable releases cannot accept new assets.
 
 Use these inputs only when you must override a default:
 
 - Use `entry` for a different entry point.
 - Use `name` for a different executable and asset name.
-- Use `release_tag` to select an existing version tag.
+- Use `release_tag` to select an existing release instead of the latest published release.
 - Use `package_manager` if Incur cannot detect the package manager.
 - Use `pnpm_version` if `package.json` does not specify the pnpm version.
 - Use `bun_version` to select the compiler version.
 - Use `smoke_command` to pass one safe argument to each tested Linux executable.
-- Use `publish: false` to leave the completed release as a draft.
-
-For the draft-first procedure, the action exposes `release_tag` for later steps.
-For example, publish the completed draft with
-`gh release edit "${{ steps.release.outputs.release_tag }}" --draft=false`.
 
 A composite action cannot set workflow concurrency. If release jobs can overlap,
 set concurrency in the caller workflow. This example runs one binary release at

--- a/release/action.yml
+++ b/release/action.yml
@@ -1,5 +1,5 @@
 name: 'Incur binary release'
-description: 'Build and release unsigned standalone binaries on GitHub'
+description: 'Build and append unsigned standalone binaries to a GitHub release'
 
 inputs:
   bun_version:
@@ -22,12 +22,8 @@ inputs:
     description: 'pnpm fallback version when packageManager does not declare one'
     required: false
     default: '10.30.2'
-  publish:
-    description: 'Publish the completed release and mark it as latest'
-    required: false
-    default: 'true'
   release_tag:
-    description: 'Existing stable release tag override matching v<package version>'
+    description: 'Existing release tag override; defaults to the latest published release'
     required: false
     default: ''
   smoke_command:
@@ -118,6 +114,7 @@ runs:
         BINARY_NAME: ${{ inputs.name }}
         BINARY_OUTPUT: 'dist/binaries'
         PACKAGE_MANAGER: ${{ steps.package-manager.outputs.name }}
+        RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
         VERSION: ${{ steps.release.outputs.version }}
       shell: bash
       run: bash "$GITHUB_ACTION_PATH/scripts/build.sh"
@@ -145,7 +142,6 @@ runs:
         EXPECTED_COMMIT: ${{ steps.release.outputs.commit }}
         EXPECTED_RELEASE_ID: ${{ steps.release.outputs.release_id }}
         GH_TOKEN: ${{ github.token }}
-        PUBLISH_RELEASE: ${{ inputs.publish }}
         RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
       shell: bash
       run: bash "$GITHUB_ACTION_PATH/scripts/upload.sh"

--- a/release/scripts/build.sh
+++ b/release/scripts/build.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 : "${GITHUB_OUTPUT:?}"
 : "${GITHUB_REPOSITORY:?}"
 : "${PACKAGE_MANAGER:?}"
+: "${RELEASE_TAG:?}"
 : "${VERSION:?}"
 
 case "$PACKAGE_MANAGER" in
@@ -25,6 +26,7 @@ args=(
   --installer
   --output "$BINARY_OUTPUT"
   --repository "$GITHUB_REPOSITORY"
+  --tag "$RELEASE_TAG"
   --version "$VERSION"
 )
 if [[ -n "${BINARY_NAME:-}" ]]; then args+=(--name "$BINARY_NAME"); fi

--- a/release/scripts/prepare-release.sh
+++ b/release/scripts/prepare-release.sh
@@ -10,30 +10,13 @@ fail() {
   exit 1
 }
 
-api_exists() {
-  local response
-  if response="$(gh api "$1" 2>&1)"; then
-    return 0
-  fi
-  if [[ "$response" == *'HTTP 404'* ]]; then
-    return 1
-  fi
-  printf '%s\n' "$response" >&2
-  exit 1
-}
-
+package_name="$(node -p "require('./package.json').name")"
 version="$(node -p "require('./package.json').version")"
+if [[ -z "$package_name" || "$package_name" == 'undefined' ]]; then
+  fail 'package.json must contain a package name.'
+fi
 if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
   fail 'package.json must contain a stable semantic version.'
-fi
-
-expected_tag="v${version}"
-release_tag="${REQUESTED_RELEASE_TAG:-$expected_tag}"
-if [[ ! "$release_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-  fail "Invalid stable release tag: ${release_tag}."
-fi
-if [[ "$release_tag" != "$expected_tag" ]]; then
-  fail "Expected release tag ${expected_tag}, received ${release_tag}."
 fi
 
 visibility="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.visibility')"
@@ -41,46 +24,26 @@ if [[ "$visibility" != 'public' ]]; then
   fail 'Binary.github supports public GitHub repositories only.'
 fi
 
-source_commit="$(git rev-parse HEAD)"
-if [[ ! "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then
-  fail 'The checked-out source has an invalid commit.'
-fi
 if [[ "${SOURCE_REF:-}" == refs/pull/* ]]; then
   fail 'Run binary releases from a trusted push or manual workflow, not a pull request.'
 fi
 
-tag_exists=false
-if api_exists "repos/${GITHUB_REPOSITORY}/git/ref/tags/${release_tag}"; then
-  tag_exists=true
-  commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${release_tag}" --jq '.sha')"
-elif [[ -n "${REQUESTED_RELEASE_TAG:-}" ]]; then
-  fail "Release tag ${release_tag} does not exist."
+if [[ -n "${REQUESTED_RELEASE_TAG:-}" ]]; then
+  endpoint="repos/${GITHUB_REPOSITORY}/releases/tags/${REQUESTED_RELEASE_TAG}"
 else
-  commit="$source_commit"
+  endpoint="repos/${GITHUB_REPOSITORY}/releases/latest"
 fi
+release="$(gh api "$endpoint")"
+release_tag="$(jq -er '.tag_name | select(type == "string" and length > 0)' <<< "$release")"
 
-if api_exists "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}"; then
-  release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}")"
-else
-  create_release() {
-    gh release create "$release_tag" \
-      --draft \
-      --generate-notes \
-      --repo "$GITHUB_REPOSITORY" \
-      --target "$source_commit" \
-      --title "$release_tag" \
-      "$@" > /dev/null
-  }
-  if [[ "$tag_exists" == 'true' ]]; then
-    create_release --verify-tag
-  else
-    create_release
-  fi
-  release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}")"
-fi
-
-if [[ "$(jq -r '.tag_name' <<< "$release")" != "$release_tag" ]]; then
+if [[ -n "${REQUESTED_RELEASE_TAG:-}" && "$release_tag" != "$REQUESTED_RELEASE_TAG" ]]; then
   fail 'The release does not match the requested tag.'
+fi
+if [[ "$release_tag" != "$version" &&
+  "$release_tag" != "v${version}" &&
+  "$release_tag" != "V${version}" &&
+  "$release_tag" != "${package_name}@${version}" ]]; then
+  fail "Release tag ${release_tag} does not identify ${package_name} ${version}."
 fi
 if [[ "$(jq -r '.prerelease' <<< "$release")" != 'false' ]]; then
   fail 'The release must not be a prerelease.'
@@ -97,9 +60,6 @@ gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${release_tag}" > /dev/null
 commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${release_tag}" --jq '.sha')"
 if [[ ! "$commit" =~ ^[0-9a-f]{40}$ ]]; then
   fail 'The release tag has an invalid commit.'
-fi
-if [[ "$tag_exists" == 'false' && "$commit" != "$source_commit" ]]; then
-  fail "Release tag ${release_tag} does not point to the checked-out commit."
 fi
 
 release_id="$(jq -r '.id' <<< "$release")"

--- a/release/scripts/upload.sh
+++ b/release/scripts/upload.sh
@@ -14,11 +14,6 @@ fail() {
   exit 1
 }
 
-publish="${PUBLISH_RELEASE:-true}"
-if [[ "$publish" != 'true' && "$publish" != 'false' ]]; then
-  fail 'publish must be true or false.'
-fi
-
 release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
 
 if [[ "$(jq -r '.id' <<< "$release")" != "$EXPECTED_RELEASE_ID" ]]; then
@@ -73,10 +68,3 @@ for file in "${assets[@]}"; do
 done
 
 gh release upload "$RELEASE_TAG" "${assets[@]}" --repo "$GITHUB_REPOSITORY"
-
-if [[ "$publish" == 'true' ]]; then
-  gh release edit "$RELEASE_TAG" \
-    --draft=false \
-    --latest \
-    --repo "$GITHUB_REPOSITORY"
-fi

--- a/release/scripts/validate-source.sh
+++ b/release/scripts/validate-source.sh
@@ -18,6 +18,10 @@ version="$(node -p "require('./package.json').version")"
 if [[ "$version" != "$EXPECTED_VERSION" ]]; then
   fail 'package.json changed between release validation and checkout.'
 fi
-if [[ "$EXPECTED_RELEASE_TAG" != "v${version}" ]]; then
+package_name="$(node -p "require('./package.json').name")"
+if [[ "$EXPECTED_RELEASE_TAG" != "$version" &&
+  "$EXPECTED_RELEASE_TAG" != "v${version}" &&
+  "$EXPECTED_RELEASE_TAG" != "V${version}" &&
+  "$EXPECTED_RELEASE_TAG" != "${package_name}@${version}" ]]; then
   fail 'The checked-out package version does not match the release tag.'
 fi

--- a/src/Binary.test.ts
+++ b/src/Binary.test.ts
@@ -59,7 +59,8 @@ test('selects the highest stable release with an exact target asset', async () =
     release('2.0.0-beta.1'),
     release('8.0.0', { prerelease: true }),
     release('9.0.0', { draft: true }),
-    release('1.4.0'),
+    release('frog@1.4.0'),
+    release("frog'@1.5.0"),
   ]
   vi.stubGlobal(
     'fetch',

--- a/src/Binary.ts
+++ b/src/Binary.ts
@@ -218,7 +218,9 @@ function selectRelease(
 
 /** Returns a stable semantic version from a release tag. */
 function stableVersion(tag: string): string | undefined {
-  const match = tag.match(/^[vV]?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/)
+  const match = tag.match(
+    /^(?:[vV]?|(?:@[A-Za-z0-9][A-Za-z0-9._~-]*\/)?[A-Za-z0-9][A-Za-z0-9._~-]*@)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/,
+  )
   if (!match) return undefined
   return `${match[1]}.${match[2]}.${match[3]}`
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -27,6 +27,7 @@ const cli = Cli.create('incur', {
       name: z.string().optional().describe('CLI name override'),
       output: z.string().optional().describe('Output directory'),
       repository: z.string().optional().describe('Public GitHub repository (owner/name)'),
+      tag: z.string().optional().describe('Exact GitHub release tag for generated installers'),
       target: z.array(z.string()).optional().describe('Target to build (repeatable)'),
       version: z.string().optional().describe('CLI version override'),
     }),
@@ -37,6 +38,7 @@ const cli = Cli.create('incur', {
         name: c.options.name,
         output: c.options.output,
         repository: c.options.repository,
+        tag: c.options.tag,
         targets: c.options.target,
         version: c.options.version,
       })

--- a/src/internal/binaryBuild.test.ts
+++ b/src/internal/binaryBuild.test.ts
@@ -167,7 +167,12 @@ describe('build', () => {
       await writeFile(file, args.join('\n'))
     }
 
-    const result = await build({ entry, execute, installer: true })
+    const result = await build({
+      entry,
+      execute,
+      installer: true,
+      tag: 'frog@1.2.3',
+    })
 
     expect(result.installers).toEqual({
       powershell: join(directory, 'dist', 'binaries', 'install.ps1'),
@@ -182,7 +187,7 @@ describe('build', () => {
     await expect(readFile(result.installers!.shell, 'utf8')).resolves.toContain(
       "repository='wevm/frog'",
     )
-    await expect(readFile(result.installers!.shell, 'utf8')).resolves.toContain("tag='v1.2.3'")
+    await expect(readFile(result.installers!.shell, 'utf8')).resolves.toContain("tag='frog@1.2.3'")
     expect((await stat(result.installers!.shell)).mode & 0o111).not.toBe(0)
   })
 

--- a/src/internal/binaryBuild.ts
+++ b/src/internal/binaryBuild.ts
@@ -54,11 +54,12 @@ export async function build(options: build.Options): Promise<build.Result> {
     throw new Error(
       'Could not resolve a public GitHub repository. Add package.json `repository` or pass --repository owner/name.',
     )
+  const tag = options.tag ?? `v${version}`
   if (repository)
     BinaryInstaller.generate({
       name,
       repository,
-      tag: `v${version}`,
+      tag,
       version,
     })
   if (repository) await assertInstallerOutput(output)
@@ -136,7 +137,7 @@ export async function build(options: build.Options): Promise<build.Result> {
           name,
           output: staging,
           repository,
-          tag: `v${version}`,
+          tag,
           version,
         })
       : undefined
@@ -220,6 +221,8 @@ export declare namespace build {
     output?: string | undefined
     /** Public GitHub repository used by generated installers. */
     repository?: string | undefined
+    /** Exact GitHub release tag used by generated installers. */
+    tag?: string | undefined
     /** Canonical targets to build. Defaults to the full supported matrix. */
     targets?: string[] | undefined
     /** CLI version override. */

--- a/src/internal/binaryInstaller.test.ts
+++ b/src/internal/binaryInstaller.test.ts
@@ -108,6 +108,12 @@ describe('generate', () => {
     expect(() => generate({ ...options, tag: 'v1.2.4' })).toThrow(
       "Release tag 'v1.2.4' does not identify version 1.2.3.",
     )
+    expect(() => generate({ ...options, tag: "frog'@1.2.3" })).toThrow(
+      "Release tag 'frog'@1.2.3' does not identify version 1.2.3.",
+    )
+    expect(generate({ ...options, tag: '@example/frog@1.2.3' }).shell).toContain(
+      "tag='@example/frog@1.2.3'",
+    )
     expect(generate({ ...options, name: '7zip' }).shell).toContain(
       'install_dir="${_7ZIP_INSTALL_DIR:-${INSTALL_DIR:-}}"',
     )

--- a/src/internal/binaryInstaller.ts
+++ b/src/internal/binaryInstaller.ts
@@ -91,7 +91,7 @@ function normalize(options: generate.Options): Release {
     throw new Error(`Invalid GitHub repository '${options.repository}'. Expected 'owner/name'.`)
   if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version))
     throw new Error(`Invalid stable version: ${options.version}`)
-  if (tag !== version && tag !== `v${version}` && tag !== `V${version}`)
+  if (stableVersion(tag) !== version)
     throw new Error(`Release tag '${options.tag}' does not identify version ${version}.`)
 
   const installVariable = `${name.toUpperCase().replaceAll(/[^A-Z0-9]/g, '_')}_INSTALL_DIR`
@@ -102,6 +102,14 @@ function normalize(options: generate.Options): Release {
     tag,
     version,
   }
+}
+
+function stableVersion(tag: string): string | undefined {
+  const match = tag.match(
+    /^(?:[vV]?|(?:@[A-Za-z0-9][A-Za-z0-9._~-]*\/)?[A-Za-z0-9][A-Za-z0-9._~-]*@)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/,
+  )
+  if (!match) return undefined
+  return `${match[1]}.${match[2]}.${match[3]}`
 }
 
 function isRepository(repository: string): boolean {

--- a/src/internal/binaryRelease.test.ts
+++ b/src/internal/binaryRelease.test.ts
@@ -45,48 +45,40 @@ afterEach(async () => {
 })
 
 describe.skipIf(process.platform === 'win32')('prepare-release.sh', () => {
-  test('creates the inferred tag and draft release at the source commit', async () => {
+  test('uses the latest published release for the package version', async () => {
+    await writeFile(join(state, 'tag-commit'), commit)
+    await writeRelease({ draft: false })
+
     await run()
 
     await expect(outputs()).resolves.toEqual({
       commit,
       release_id: '17',
-      release_tag: 'v1.2.3',
+      release_tag: '@example/demo@1.2.3',
       version: '1.2.3',
     })
-    await expect(calls()).resolves.toContainEqual([
-      'release',
-      'create',
-      'v1.2.3',
-      '--draft',
-      '--generate-notes',
-      '--repo',
-      'wevm/demo',
-      '--target',
-      commit,
-      '--title',
-      'v1.2.3',
-    ])
+    await expect(calls()).resolves.toContainEqual(['api', 'repos/wevm/demo/releases/latest'])
+    await expect(calls()).resolves.not.toContainEqual(expect.arrayContaining(['release', 'create']))
   })
 
-  test('reuses an existing matching draft without moving its tag', async () => {
+  test('uses an explicit matching release tag', async () => {
     await writeFile(join(state, 'tag-commit'), commit)
-    await writeRelease({ draft: true })
+    await writeRelease({ draft: true, tag: 'v1.2.3' })
 
-    await run()
+    await run({ REQUESTED_RELEASE_TAG: 'v1.2.3' })
 
     await expect(outputs()).resolves.toMatchObject({
       commit,
       release_id: '17',
       release_tag: 'v1.2.3',
     })
-    await expect(calls()).resolves.not.toContainEqual(expect.arrayContaining(['release', 'create']))
+    await expect(calls()).resolves.toContainEqual(['api', 'repos/wevm/demo/releases/tags/v1.2.3'])
   })
 
   test('resolves an existing tag instead of requiring the source commit', async () => {
     const taggedCommit = commit
     await writeFile(join(state, 'tag-commit'), taggedCommit)
-    await writeRelease({ draft: true })
+    await writeRelease({ draft: false })
     await writeFile(join(repository, 'README.md'), 'fixture\n')
     await exec('git', ['add', 'README.md'], { cwd: repository })
     await exec('git', ['commit', '--quiet', '--message', 'new source'], { cwd: repository })
@@ -96,41 +88,13 @@ describe.skipIf(process.platform === 'win32')('prepare-release.sh', () => {
     await expect(outputs()).resolves.toMatchObject({ commit: taggedCommit })
   })
 
-  test('does not create a missing explicit release tag', async () => {
-    await expect(run({ REQUESTED_RELEASE_TAG: 'v1.2.3' })).rejects.toMatchObject({
-      stderr: 'Release tag v1.2.3 does not exist.\n',
-    })
-    await expect(calls()).resolves.not.toContainEqual(expect.arrayContaining(['release', 'create']))
-  })
-
-  test('creates a missing draft for an existing explicit release tag', async () => {
+  test('rejects a release for another package version', async () => {
     await writeFile(join(state, 'tag-commit'), commit)
+    await writeRelease({ draft: false, tag: '@example/demo@1.2.4' })
 
-    await run({ REQUESTED_RELEASE_TAG: 'v1.2.3' })
-
-    await expect(outputs()).resolves.toMatchObject({
-      commit,
-      release_id: '17',
-      release_tag: 'v1.2.3',
+    await expect(run()).rejects.toMatchObject({
+      stderr: 'Release tag @example/demo@1.2.4 does not identify @example/demo 1.2.3.\n',
     })
-    await expect(calls()).resolves.toContainEqual(
-      expect.arrayContaining(['release', 'create', 'v1.2.3']),
-    )
-    await expect(calls()).resolves.toContainEqual(expect.arrayContaining(['--verify-tag']))
-  })
-
-  test('reuses an existing published release', async () => {
-    await writeFile(join(state, 'tag-commit'), commit)
-    await writeRelease({ draft: false })
-
-    await run()
-
-    await expect(outputs()).resolves.toMatchObject({
-      commit,
-      release_id: '17',
-      release_tag: 'v1.2.3',
-    })
-    await expect(calls()).resolves.not.toContainEqual(expect.arrayContaining(['release', 'create']))
   })
 
   test('rejects an immutable published release', async () => {
@@ -144,7 +108,7 @@ describe.skipIf(process.platform === 'win32')('prepare-release.sh', () => {
   })
 
   test('does not treat GitHub API failures as missing resources', async () => {
-    await writeFile(join(state, 'tag-error'), '')
+    await writeFile(join(state, 'release-error'), '')
 
     await expect(run()).rejects.toMatchObject({
       stderr: 'gh: Service Unavailable (HTTP 503)\n',
@@ -164,47 +128,22 @@ describe.skipIf(process.platform === 'win32')('upload.sh', () => {
   test.each([
     { draft: true, state: 'draft' },
     { draft: false, state: 'published' },
-  ])('leaves a $state release unpublished when opted out', async ({ draft }) => {
+  ])('appends assets without changing the $state release state', async ({ draft }) => {
     await writeFile(join(state, 'tag-commit'), commit)
     await writeRelease({ draft })
     const assets = await writeAssets()
 
-    await runUpload({ PUBLISH_RELEASE: 'false' })
+    await runUpload()
 
     await expect(calls()).resolves.toContainEqual([
       'release',
       'upload',
-      'v1.2.3',
+      '@example/demo@1.2.3',
       ...assets,
       '--repo',
       'wevm/demo',
     ])
     await expect(calls()).resolves.not.toContainEqual(expect.arrayContaining(['release', 'edit']))
-  })
-
-  test('publishes the completed release as latest by default', async () => {
-    await writeFile(join(state, 'tag-commit'), commit)
-    await writeRelease({ draft: true })
-    const assets = await writeAssets()
-
-    await runUpload()
-
-    const calls_ = await calls()
-    expect(calls_.slice(-2)).toEqual([
-      ['release', 'upload', 'v1.2.3', ...assets, '--repo', 'wevm/demo'],
-      ['release', 'edit', 'v1.2.3', '--draft=false', '--latest', '--repo', 'wevm/demo'],
-    ])
-  })
-
-  test('rejects an invalid publish input before uploading assets', async () => {
-    await writeFile(join(state, 'tag-commit'), commit)
-    await writeRelease({ draft: true })
-    await writeAssets()
-
-    await expect(runUpload({ PUBLISH_RELEASE: 'yes' })).rejects.toMatchObject({
-      stderr: 'publish must be true or false.\n',
-    })
-    await expect(readFile(join(state, 'calls'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   test('does not upload to a release that became immutable', async () => {
@@ -266,7 +205,7 @@ function runUpload(env: NodeJS.ProcessEnv = {}) {
       GH_TOKEN: 'test',
       GITHUB_REPOSITORY: 'wevm/demo',
       PATH: `${bin}${delimiter}${process.env.PATH}`,
-      RELEASE_TAG: 'v1.2.3',
+      RELEASE_TAG: '@example/demo@1.2.3',
       ...env,
     },
   })
@@ -292,7 +231,11 @@ async function writeAssets() {
   return names.map((name) => join(directory_, name))
 }
 
-function writeRelease(options: { draft: boolean; immutable?: boolean | undefined }) {
+function writeRelease(options: {
+  draft: boolean
+  immutable?: boolean | undefined
+  tag?: string | undefined
+}) {
   return writeFile(
     join(state, 'release.json'),
     JSON.stringify({
@@ -301,7 +244,7 @@ function writeRelease(options: { draft: boolean; immutable?: boolean | undefined
       id: 17,
       immutable: options.immutable ?? false,
       prerelease: false,
-      tag_name: 'v1.2.3',
+      tag_name: options.tag ?? '@example/demo@1.2.3',
     }),
   )
 }
@@ -323,7 +266,32 @@ if (args[0] === 'api' && args[1] === 'repos/wevm/demo') {
   process.exit(0)
 }
 
-if (args[0] === 'api' && args[1] === 'repos/wevm/demo/git/ref/tags/v1.2.3') {
+if (
+  args[0] === 'api' &&
+  (args[1] === 'repos/wevm/demo/releases/latest' ||
+    args[1].startsWith('repos/wevm/demo/releases/tags/'))
+) {
+  if (fs.existsSync(path.join(state, 'release-error'))) {
+    process.stderr.write('gh: Service Unavailable (HTTP 503)\\n')
+    process.exit(1)
+  }
+  if (!fs.existsSync(release)) {
+    process.stderr.write('gh: Not Found (HTTP 404)\\n')
+    process.exit(1)
+  }
+  const value = JSON.parse(fs.readFileSync(release, 'utf8'))
+  if (
+    args[1].startsWith('repos/wevm/demo/releases/tags/') &&
+    args[1].slice('repos/wevm/demo/releases/tags/'.length) !== value.tag_name
+  ) {
+    process.stderr.write('gh: Not Found (HTTP 404)\\n')
+    process.exit(1)
+  }
+  process.stdout.write(JSON.stringify(value) + '\\n')
+  process.exit(0)
+}
+
+if (args[0] === 'api' && args[1].startsWith('repos/wevm/demo/git/ref/tags/')) {
   if (fs.existsSync(path.join(state, 'tag-error'))) {
     process.stderr.write('gh: Service Unavailable (HTTP 503)\\n')
     process.exit(1)
@@ -336,39 +304,13 @@ if (args[0] === 'api' && args[1] === 'repos/wevm/demo/git/ref/tags/v1.2.3') {
   process.exit(0)
 }
 
-if (args[0] === 'api' && args[1] === 'repos/wevm/demo/commits/v1.2.3') {
+if (args[0] === 'api' && args[1].startsWith('repos/wevm/demo/commits/')) {
   if (!fs.existsSync(tagCommit)) process.exit(1)
   process.stdout.write(fs.readFileSync(tagCommit, 'utf8') + '\\n')
   process.exit(0)
 }
 
-if (args[0] === 'api' && args[1] === 'repos/wevm/demo/releases/tags/v1.2.3') {
-  if (!fs.existsSync(release)) {
-    process.stderr.write('gh: Not Found (HTTP 404)\\n')
-    process.exit(1)
-  }
-  process.stdout.write(fs.readFileSync(release, 'utf8') + '\\n')
-  process.exit(0)
-}
-
-if (args[0] === 'release' && args[1] === 'create') {
-  const target = args[args.indexOf('--target') + 1]
-  if (!fs.existsSync(tagCommit)) fs.writeFileSync(tagCommit, target)
-  fs.writeFileSync(
-    release,
-    JSON.stringify({
-      draft: true,
-      id: 17,
-      prerelease: false,
-      tag_name: args[2],
-    }),
-  )
-  process.exit(0)
-}
-
 if (args[0] === 'release' && args[1] === 'upload') process.exit(0)
-
-if (args[0] === 'release' && args[1] === 'edit') process.exit(0)
 
 process.stderr.write('Unexpected gh call: ' + JSON.stringify(args) + '\\n')
 process.exit(1)


### PR DESCRIPTION
Appends standalone binary assets to the latest matching GitHub release and carries Changesets workspace tags into generated installers. This avoids the 404 caused by inferring a root-style `v<version>` release.