### PR TITLE
ci: update action tag on release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,3 +40,9 @@ jobs:
           version: pnpm run changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Action tag
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          git tag --annotate --force v1 "$GITHUB_SHA" --message v1
+          git push --force origin refs/tags/v1


### PR DESCRIPTION
Moves the `v1` action tag after each successful Changesets publish, keeping the documented `wevm/incur/release@v1` reference on the latest compatible released action.