### PR TITLE
chore: add action tag changeset

### DIFF
--- a/.changeset/tidy-action-tag.md
+++ b/.changeset/tidy-action-tag.md
@@ -1,0 +1,5 @@
+---
+'incur': patch
+---
+
+Added GitHub action tag.


### PR DESCRIPTION
Adds a patch changeset for the new `v1` action-tag automation, triggering an Incur release that advances the documented major action tag.